### PR TITLE
Add pytest suite and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+import werkzeug
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Flask 2.3 expects werkzeug.__version__ which was removed in Werkzeug 3
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,53 @@
+import sqlite3
+import os
+import functions
+
+
+def setup_db(tmp_path):
+    db_path = tmp_path / 'bookings.db'
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            language TEXT NOT NULL,
+            time_start TEXT NOT NULL,
+            time_end TEXT NOT NULL
+        )
+        """
+    )
+    cursor.execute(
+        "INSERT INTO bookings (name, email, phone, language, time_start, time_end) VALUES (?, ?, ?, ?, ?, ?)",
+        ("Alice", "alice@example.com", "123", "English", "10", "11"),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_generate_secret_key_length_and_uniqueness():
+    key1 = functions.generate_secret_key()
+    key2 = functions.generate_secret_key()
+    assert len(key1) == 64
+    assert len(key2) == 64
+    assert key1 != key2
+
+
+def test_booking_exists_true(tmp_path, monkeypatch):
+    setup_db(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert functions.booking_exists(
+        "Alice", "alice@example.com", "123", "English", "10", "11"
+    )
+
+
+def test_booking_exists_false(tmp_path, monkeypatch):
+    setup_db(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert not functions.booking_exists(
+        "Bob", "bob@example.com", "456", "Swedish", "10", "11"
+    )

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1,0 +1,21 @@
+import pytest
+import website
+
+
+@pytest.fixture
+def client():
+    website.app.config.update({"TESTING": True})
+    with website.app.test_client() as client:
+        yield client
+
+
+def test_index_route(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Bokning" in response.data
+
+
+def test_login_route(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert b"Login" in response.data


### PR DESCRIPTION
## Summary
- add unit tests for helper functions and flask routes
- ensure Werkzeug compatibility for tests
- configure GitHub Actions workflow to run pytest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00a25120c832d95cc93004df81c7d