### PR TITLE
Return correct 404 HTTP status

### DIFF
--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -19,3 +19,9 @@ def test_login_route(client):
     response = client.get("/login")
     assert response.status_code == 200
     assert b"Login" in response.data
+
+
+def test_404_route(client):
+    response = client.get("/not-found")
+    assert response.status_code == 404
+    assert b"Detta var inte vad du letade efter." in response.data

--- a/website.py
+++ b/website.py
@@ -307,7 +307,14 @@ def login():
 
 @app.errorhandler(404)
 def page_not_found(e):
-    return render_template('error.html', message='Detta var inte vad du letade efter.', error_name='404')
+    return (
+        render_template(
+            'error.html',
+            message='Detta var inte vad du letade efter.',
+            error_name='404',
+        ),
+        404,
+    )
 if __name__ == '__main__':
     # Connect to the database and create the 'bookings' table if it doesn't exist
     conn = sqlite3.connect('bookings.db')


### PR DESCRIPTION
## Summary
- ensure error pages respond with HTTP 404
- test missing routes return proper 404 status and message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00b5d4568832d801516751a930a8f