### PR TITLE
Harden forms with CSRF tokens and secure settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 python-dotenv
 datetime
 pytest
+Flask-WTF

--- a/templates/billing.html
+++ b/templates/billing.html
@@ -9,6 +9,7 @@ Faktureringsinformation
 {% block content %}
 <h1>Faktureringsinformation</h1>
 <form method="post" action="/billing">
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   
   <label class="container" for="avtals_kund">Är du en avtalskund?
 
@@ -66,9 +67,7 @@ Faktureringsinformation
   }
   
   // Initial invocation to set the initial state based on the checkbox state
-  toggleFields();
-  </script>
+    toggleFields();
+    </script>
 
-  
-</form>
-  {% endblock %}  
+{% endblock %}

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -64,11 +64,15 @@
     </div>
 
     <script>
+        const csrfToken = "{{ csrf_token() }}";
         function acceptJob(jobId) {
             // Display loading overlay
             document.getElementById('loadingOverlay').style.display = 'flex';
 
-            fetch(`/jobs/${jobId}`, { method: 'POST' })
+            fetch(`/jobs/${jobId}`, {
+                method: 'POST',
+                headers: { 'X-CSRFToken': csrfToken }
+            })
                 .then(response => {
                     // Hide loading overlay when the request is complete
                     document.getElementById('loadingOverlay').style.display = 'none';

--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -35,6 +35,7 @@
         Märkning: {{avtalskund_marking}}
         {% endif %}
         <form method="post" action="#">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="submit" value="Bekräfta" name="Bekräfta"/>
         </form>
     </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -29,6 +29,7 @@
         <td>
           {% if b[4] == 'pending' %}
           <form method="post" action="{{ url_for('cancel_booking', booking_id=b[0]) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="cancel-button">Avbryt</button>
           </form>
           {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@ Bokning av översättare
     <h1>Bokning av översättare</h1>
     
     <form action="/submit" method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         {% if not logged_in %}
         <label for="name">Fullständigt namn:</label>
         <input type="text" id="name" name="name" value="{{ user_name }}" required><br><br>

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,6 +9,7 @@
 {% block content %}
 <h1>Login</h1>
 <form action="/login" method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% if error %}
         <p class="error">{{ error }}</p>
     {% endif %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -6,6 +6,7 @@
 {% block content %}
 <h1>Registrera konto</h1>
 <form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <label for="name">Namn:</label>
   <input type="text" id="name" name="name" required><br><br>
   <label for="phone">Telefonnummer:</label>

--- a/templates/start.html
+++ b/templates/start.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>Start Script</h1>
 <form action="/start_script" method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="submit" value="Start">
 </form>
 {% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -7,6 +7,7 @@
 <h1>Logga in</h1>
 {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
 <form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <label for="email">E-post:</label>
   <input type="email" id="email" name="email" required><br><br>
   <label for="password">Lösenord:</label>

--- a/website.py
+++ b/website.py
@@ -10,6 +10,7 @@ import time
 import functions
 from itertools import combinations
 import subprocess
+from flask_wtf.csrf import CSRFProtect
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -29,6 +30,11 @@ languages = [
 load_dotenv()
 app = Flask(__name__)
 app.secret_key = functions.generate_secret_key()
+app.config.update(
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SECURE=True,
+)
+csrf = CSRFProtect(app)
 
 # Define the password for accessing the /jobs route
 PASSWORD = os.getenv('password')
@@ -512,4 +518,5 @@ if __name__ == '__main__':
             cursor.execute(f"ALTER TABLE logins ADD COLUMN {col} TEXT")
 
     conn.close()
-    app.run(port=8080, host="0.0.0.0", debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG") == "1"
+    app.run(port=8080, host="0.0.0.0", debug=debug_mode)


### PR DESCRIPTION
## Summary
- Add Flask-WTF and CSRF protection to all forms and AJAX job acceptance
- Enforce secure/HTTPOnly session cookies and disable debug by default

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a015281c2c832da7aaf5f615978003