### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Run Tests
 
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-cool08/tolka/security/code-scanning/2](https://github.com/Mr-cool08/tolka/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to implement this is to add `permissions: contents: read` at the root level of the workflow file, above the `jobs:` key. This ensures that all jobs in the workflow inherit these minimal permissions unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
