### PR TITLE
Add two-factor authentication with TOTP

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -2,6 +2,7 @@ import sqlite3
 import secrets
 import os
 import hashlib
+import pyotp
 
 
 def generate_secret_key():
@@ -65,9 +66,10 @@ def ensure_test_user(email="test@example.com", password="Masbo124"):
             return
     pwd_hash, pwd_salt = hash_password(password)
     email_hash, email_salt = hash_email(email)
+    totp_secret = pyotp.random_base32()
     cursor.execute(
-        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        ("Test User", email_hash, email_salt, "0000000000", pwd_hash, pwd_salt, "", "", ""),
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("Test User", email_hash, email_salt, "0000000000", pwd_hash, pwd_salt, "", "", "", totp_secret),
     )
     conn.commit()
     conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 python-dotenv
 datetime
 pytest
+pyotp

--- a/templates/verify_2fa.html
+++ b/templates/verify_2fa.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Two-Factor Verification{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Tvåfaktorsautentisering</h1>
+{% if secret %}
+<p>Skanna eller lägg till denna nyckel i din autentiseringsapp:</p>
+<p><strong>{{ secret }}</strong></p>
+{% endif %}
+{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+<form method="post">
+  <label for="token">Kod:</label>
+  <input type="text" id="token" name="token" required>
+  <input type="submit" value="Verifiera">
+</form>
+{% endblock %}

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
+import sqlite3
+import pyotp
 import website
 
 
@@ -38,3 +40,68 @@ def test_404_route(client):
     response = client.get("/not-found")
     assert response.status_code == 404
     assert "Detta var inte vad du letade efter." in response.get_data(as_text=True)
+
+
+def test_two_factor_requires_pending_user(client):
+    response = client.get("/two_factor")
+    assert response.status_code == 302
+    assert "/user_login" in response.headers["Location"]
+
+
+def test_signup_login_logout_flow(tmp_path, monkeypatch):
+    db_path = tmp_path / "database.db"
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            language TEXT NOT NULL,
+            time_start TEXT NOT NULL,
+            time_end TEXT NOT NULL,
+            status TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.chdir(tmp_path)
+    website.app.config.update({"TESTING": True})
+    with website.app.test_client() as client:
+        signup_data = {
+            "name": "Tester",
+            "email": "tester@example.com",
+            "phone": "123456",
+            "password": "secret",
+        }
+        resp = client.post("/signup", data=signup_data)
+        assert resp.status_code == 302
+        with client.session_transaction() as sess:
+            token = pyotp.TOTP(sess["new_totp_secret"]).now()
+        resp = client.post("/two_factor", data={"token": token})
+        assert resp.status_code == 302
+        resp = client.get("/logout")
+        assert resp.status_code == 302
+        home = client.get("/")
+        assert home.status_code == 200
+        assert "Skapa konto" in home.get_data(as_text=True)

--- a/website.py
+++ b/website.py
@@ -8,8 +8,7 @@ from email.mime.multipart import MIMEMultipart
 from dotenv import load_dotenv
 import time
 import functions
-from itertools import combinations
-import subprocess
+import pyotp
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -34,11 +33,10 @@ app.secret_key = functions.generate_secret_key()
 PASSWORD = os.getenv('password')
 
 
-@app.route('/logout')
+@app.route('/logout', methods=['GET', 'POST'])
 def logout():
-    session.pop('authenticated', None)
-    session.pop('user_id', None)
-    session.pop('user_email', None)
+    """Clear the user session and redirect to the home page."""
+    session.clear()
     return redirect(url_for('home'))
 
 
@@ -94,6 +92,7 @@ def signup():
         email_billing_address = request.form.get('email_billing_address', '')
         pwd_hash, salt = functions.hash_password(password)
         email_hash, email_salt = functions.hash_email(email)
+        totp_secret = pyotp.random_base32()
         conn = sqlite3.connect('database.db')
         cursor = conn.cursor()
         cursor.execute("SELECT email, email_salt FROM logins")
@@ -105,8 +104,8 @@ def signup():
             """
             INSERT INTO logins (
                 name, email, email_salt, phone, password_hash, salt,
-                organization_number, billing_address, email_billing_address
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                organization_number, billing_address, email_billing_address, totp_secret
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name,
@@ -118,14 +117,16 @@ def signup():
                 organization_number,
                 billing_address,
                 email_billing_address,
+                totp_secret,
             ),
         )
         user_id = cursor.lastrowid
         conn.commit()
         conn.close()
-        session['user_id'] = user_id
-        session['user_email'] = email
-        return redirect(url_for('home'))
+        session['pending_user_id'] = user_id
+        session['pending_user_email'] = email
+        session['new_totp_secret'] = totp_secret
+        return redirect(url_for('two_factor'))
     return render_template('signup.html')
 
 
@@ -141,12 +142,36 @@ def user_login():
             user_id, email_hash, email_salt, pwd_hash, pwd_salt = row
             if functions.verify_email(email, email_hash, email_salt) and functions.verify_password(password, pwd_hash, pwd_salt):
                 conn.close()
-                session['user_id'] = user_id
-                session['user_email'] = email
-                return redirect(url_for('home'))
+                session['pending_user_id'] = user_id
+                session['pending_user_email'] = email
+                return redirect(url_for('two_factor'))
         conn.close()
         return render_template('user_login.html', error='Invalid credentials')
     return render_template('user_login.html')
+
+@app.route('/two_factor', methods=['GET', 'POST'])
+def two_factor():
+    if 'pending_user_id' not in session:
+        return redirect(url_for('user_login'))
+    secret = session.get('new_totp_secret')
+    if not secret:
+        conn = sqlite3.connect('database.db')
+        cursor = conn.cursor()
+        cursor.execute('SELECT totp_secret FROM logins WHERE id = ?', (session['pending_user_id'],))
+        row = cursor.fetchone()
+        conn.close()
+        if row:
+            secret = row[0]
+    if request.method == 'POST':
+        token = request.form['token']
+        totp = pyotp.TOTP(secret)
+        if totp.verify(token):
+            session['user_id'] = session.pop('pending_user_id')
+            session['user_email'] = session.pop('pending_user_email')
+            session.pop('new_totp_secret', None)
+            return redirect(url_for('home'))
+        return render_template('verify_2fa.html', error='Invalid code', secret=secret)
+    return render_template('verify_2fa.html', secret=secret)
 
 @app.route('/health')
 def health():
@@ -518,7 +543,8 @@ if __name__ == '__main__':
                     salt TEXT NOT NULL,
                     organization_number TEXT,
                     billing_address TEXT,
-                    email_billing_address TEXT)''')
+                    email_billing_address TEXT,
+                    totp_secret TEXT)''')
 
     cursor.execute("PRAGMA table_info(logins)")
     login_columns = [info[1] for info in cursor.fetchall()]
@@ -527,6 +553,7 @@ if __name__ == '__main__':
         'billing_address',
         'email_billing_address',
         'email_salt',
+        'totp_secret',
     ]
     for col in extra_cols:
         if col not in login_columns:


### PR DESCRIPTION
## Summary
- integrate pyotp-based TOTP for user signup and login
- store per-user TOTP secrets and add verification route
- clear session on logout and allow POST requests, fixing "not found" after logout
- cover two-factor and logout flow with template and tests
- remove stray unused imports in web application

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a093a9d038832da1235176c71943ae