### PR TITLE
Make two-factor authentication optional

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -25,6 +25,9 @@
   <label for="email_billing_address">E-postadress för fakturering:</label>
   <input type="email" id="email_billing_address" name="email_billing_address"><br><br>
 
+  <input type="checkbox" id="enable_2fa" name="enable_2fa">
+  <label for="enable_2fa">Aktivera tvåfaktorsautentisering</label><br><br>
+
   <input type="submit" value="Skapa konto">
 </form>
 {% endblock %}

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
+import sqlite3
+import pyotp
+import functions
 import website
 
 
@@ -44,6 +47,91 @@ def test_two_factor_requires_pending_user(client):
     response = client.get("/two_factor")
     assert response.status_code == 302
     assert "/user_login" in response.headers["Location"]
+
+
+def test_user_login_without_2fa_redirects_home(client):
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL UNIQUE,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.commit()
+
+    email = "user-no2fa@example.com"
+    password = "secret"
+    pwd_hash, pwd_salt = functions.hash_password(password)
+    email_hash, email_salt = functions.hash_email(email)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("Test", email_hash, email_salt, "000", pwd_hash, pwd_salt),
+    )
+    user_id = cursor.lastrowid
+    conn.commit()
+    conn.close()
+
+    response = client.post("/user_login", data={"email": email, "password": password})
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+
+    conn = sqlite3.connect("database.db")
+    conn.execute("DELETE FROM logins WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
+
+
+def test_user_login_with_2fa_redirects_two_factor(client):
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL UNIQUE,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.commit()
+
+    email = "user-2fa@example.com"
+    password = "secret"
+    pwd_hash, pwd_salt = functions.hash_password(password)
+    email_hash, email_salt = functions.hash_email(email)
+    totp_secret = pyotp.random_base32()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', ?)",
+        ("Test", email_hash, email_salt, "000", pwd_hash, pwd_salt, totp_secret),
+    )
+    user_id = cursor.lastrowid
+    conn.commit()
+    conn.close()
+
+    response = client.post("/user_login", data={"email": email, "password": password})
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/two_factor"
+
+    conn = sqlite3.connect("database.db")
+    conn.execute("DELETE FROM logins WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
 
 
 def test_login_respects_application_root(monkeypatch):


### PR DESCRIPTION
## Summary
- Allow users to opt into two-factor authentication during signup
- Skip two-factor login step for accounts without a TOTP secret
- Add tests for login flows with and without two-factor authentication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0b5db4814832dbcb9811bbf9bc599