### PR TITLE
Add two-factor authentication setup guide

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -26,7 +26,8 @@
   <input type="email" id="email_billing_address" name="email_billing_address"><br><br>
 
   <input type="checkbox" id="enable_2fa" name="enable_2fa">
-  <label for="enable_2fa">Aktivera tvåfaktorsautentisering</label><br><br>
+  <label for="enable_2fa">Aktivera tvåfaktorsautentisering</label>
+  (<a href="{{ url_for('two_factor_guide') }}">Hur gör jag?</a>)<br><br>
 
   <input type="submit" value="Skapa konto">
 </form>

--- a/templates/two_factor_guide.html
+++ b/templates/two_factor_guide.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}2FA Setup Guide{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Set up Two-Factor Authentication (2FA)</h1>
+<ol>
+  <li><strong>Start on the service you want to secure.</strong> Open its settings and find "Two-Factor Authentication" or similar.</li>
+  <li><strong>Select "Authenticator app".</strong></li>
+  <li><strong>Scan the QR code or enter the key.</strong> In your authenticator app tap "+" to add a new account.</li>
+  <li><strong>Enter the 6-digit code.</strong> Type the code from the app back into the website.</li>
+  <li><strong>Save your backup codes.</strong></li>
+</ol>
+<h2>Popular Authenticator Apps</h2>
+<ul>
+  <li><strong>Google Authenticator:</strong> Tap the "+" button then "Scan a QR code".</li>
+  <li><strong>Microsoft Authenticator:</strong> Sign in if needed, tap "Add account", choose "Other".</li>
+  <li><strong>Authy:</strong> Create a free account to sync codes across devices.</li>
+  <li><strong>1Password:</strong> Store your 2FA codes with your passwords.</li>
+</ul>
+<h2>Examples</h2>
+<h3>Google Account</h3>
+<ol>
+  <li>Visit <code>myaccount.google.com/security</code>.</li>
+  <li>Under "Signing in to Google" choose "2-Step Verification" &gt; "Authenticator app".</li>
+  <li>Scan the QR code and enter the 6-digit code.</li>
+</ol>
+<h3>Facebook</h3>
+<ol>
+  <li>Open Settings &gt; Password and Security.</li>
+  <li>Under "Two-factor authentication" choose "Authentication App".</li>
+  <li>Scan the QR code and confirm with the app code.</li>
+</ol>
+<h3>Instagram</h3>
+<ol>
+  <li>Go to your profile &gt; Menu &gt; Settings and privacy &gt; Accounts Center.</li>
+  <li>Select Password and security &gt; Two-factor authentication &gt; Authentication app.</li>
+  <li>Copy or scan the code, then enter the 6-digit code to finish.</li>
+</ol>
+<p>Codes refresh every 30 seconds. Transfer your authenticator app before changing phones and keep backup codes safe.</p>
+{% endblock %}

--- a/templates/verify_2fa.html
+++ b/templates/verify_2fa.html
@@ -5,6 +5,7 @@
 {% endblock %}
 {% block content %}
 <h1>Tvåfaktorsautentisering</h1>
+<p><a href="{{ url_for('two_factor_guide') }}">Behöver du hjälp med autentiseringsappen?</a></p>
 {% if secret %}
 <p>Skanna eller lägg till denna nyckel i din autentiseringsapp:</p>
 <p><strong>{{ secret }}</strong></p>

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -37,6 +37,12 @@ def test_health_route(client):
     assert "OK" in response.get_data(as_text=True)
 
 
+def test_two_factor_guide_route(client):
+    response = client.get("/2fa-guide")
+    assert response.status_code == 200
+    assert "Two-Factor Authentication" in response.get_data(as_text=True)
+
+
 def test_404_route(client):
     response = client.get("/not-found")
     assert response.status_code == 404

--- a/website.py
+++ b/website.py
@@ -185,6 +185,11 @@ def two_factor():
         return render_template('verify_2fa.html', error='Invalid code', secret=secret)
     return render_template('verify_2fa.html', secret=secret)
 
+
+@app.route('/2fa-guide')
+def two_factor_guide():
+    return render_template('two_factor_guide.html')
+
 @app.route('/health')
 def health():
     """Health check endpoint used by deployment platforms."""


### PR DESCRIPTION
## Summary
- add `/2fa-guide` route and template with simple instructions for setting up authenticator apps
- link to the guide from the sign-up form and 2FA verification page
- include test ensuring the guide route is accessible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ba1bc494832d8baaf3348d2b4c5a