### PR TITLE
Hide 2FA secret during login

### DIFF
--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -140,6 +140,53 @@ def test_user_login_with_2fa_redirects_two_factor(client):
     conn.close()
 
 
+def test_two_factor_secret_not_shown_on_login(client):
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL UNIQUE,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.commit()
+
+    email = "user-secret@example.com"
+    password = "secret"
+    pwd_hash, pwd_salt = functions.hash_password(password)
+    email_hash, email_salt = functions.hash_email(email)
+    totp_secret = pyotp.random_base32()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', ?)",
+        ("Test", email_hash, email_salt, "000", pwd_hash, pwd_salt, totp_secret),
+    )
+    user_id = cursor.lastrowid
+    conn.commit()
+    conn.close()
+
+    response = client.post("/user_login", data={"email": email, "password": password})
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/two_factor"
+
+    response = client.get("/two_factor")
+    assert response.status_code == 200
+    assert totp_secret not in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    conn.execute("DELETE FROM logins WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
+
+
 def test_login_respects_application_root(monkeypatch):
     import os
     import website

--- a/website.py
+++ b/website.py
@@ -166,6 +166,7 @@ def two_factor():
     if 'pending_user_id' not in session:
         return redirect(url_for('user_login'))
     secret = session.get('new_totp_secret')
+    display_secret = secret
     if not secret:
         conn = sqlite3.connect('database.db')
         cursor = conn.cursor()
@@ -182,8 +183,8 @@ def two_factor():
             session['user_email'] = session.pop('pending_user_email')
             session.pop('new_totp_secret', None)
             return redirect(url_for('home'))
-        return render_template('verify_2fa.html', error='Invalid code', secret=secret)
-    return render_template('verify_2fa.html', secret=secret)
+        return render_template('verify_2fa.html', error='Invalid code', secret=display_secret)
+    return render_template('verify_2fa.html', secret=display_secret)
 
 
 @app.route('/2fa-guide')


### PR DESCRIPTION
## Summary
- Prevent users from seeing their TOTP secret during regular 2FA login
- Add regression test ensuring 2FA secret isn't displayed when logging in

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bbae9c84832d9a6919685fecd505