### PR TITLE
Style 2FA help button to match site design

### DIFF
--- a/static/style/auth.css
+++ b/static/style/auth.css
@@ -20,6 +20,20 @@ input[type="submit"] {
     cursor: pointer;
 }
 
+button {
+    padding: 10px;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 10px;
+}
+
+button:hover {
+    background-color: #555;
+}
+
 .error {
     color: red;
 }


### PR DESCRIPTION
## Summary
- Style 2FA helper button like other site buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bfa89c84832da592d9f67ed421ce