### PR TITLE
Improve mobile responsiveness and add account removal link

### DIFF
--- a/static/style/base.css
+++ b/static/style/base.css
@@ -62,6 +62,10 @@ p {
     form {
         padding: 15px;
     }
+
+    footer {
+        position: static;
+    }
 }
 
 

--- a/static/style/dashboard.css
+++ b/static/style/dashboard.css
@@ -91,7 +91,24 @@
 }
 
 @media (max-width: 600px) {
+    .dashboard-container {
+        padding: 15px;
+        width: 95%;
+    }
+
     .dashboard-table {
         min-width: 500px;
+    }
+
+    .dashboard-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .dashboard-button {
+        margin-right: 0;
+        width: 100%;
+        text-align: center;
     }
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -44,6 +44,7 @@
   <div class="dashboard-actions">
     <a href="{{ url_for('index') }}" class="dashboard-button">Gör ny bokning</a>
     <a href="{{ url_for('logout') }}" class="dashboard-button">Logga ut</a>
+    <a href="{{ removal_link }}" class="dashboard-button">Ta bort konto</a>
   </div>
 </div>
 {% else %}

--- a/website.py
+++ b/website.py
@@ -11,6 +11,7 @@ import functions
 from itertools import combinations
 import subprocess
 import pyotp
+import urllib.parse
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -54,8 +55,19 @@ def home():
             (user_email,),
         )
         bookings = cursor.fetchall()
+        cursor.execute("SELECT email FROM logins WHERE id = ?", (session['user_id'],))
+        row = cursor.fetchone()
+        hashed_email = row[0] if row else ''
         conn.close()
-        return render_template('home.html', bookings=bookings)
+        body = urllib.parse.quote_plus(
+            f"Please remove my account. Email hash: {hashed_email}"
+        )
+        removal_link = (
+            f"mailto:placeholder@tolkar.se?subject=Remove%20account&body={body}"
+        )
+        return render_template(
+            'home.html', bookings=bookings, removal_link=removal_link
+        )
     return render_template('home.html')
 
 


### PR DESCRIPTION
## Summary
- Improve dashboard layout for mobile screens and adjust base footer on small devices.
- Add account removal button on dashboard that opens a prefilled email including hashed email.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d680488c832d859dbb1756db79ef