### PR TITLE
Style account deletion email and remove test user TOTP secret

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -2,7 +2,6 @@ import sqlite3
 import secrets
 import os
 import hashlib
-import pyotp
 
 
 def generate_secret_key():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -114,4 +114,4 @@ def test_ensure_test_user_creates_single_entry(tmp_path, monkeypatch):
         1 for e_hash, e_salt, _ in rows if functions.verify_email('test@example.com', e_hash, e_salt)
     )
     assert count == 1
-    assert all(len(totp) == 32 for _, _, totp in rows)
+    assert all(totp == '' for _, _, totp in rows)

--- a/website.py
+++ b/website.py
@@ -59,11 +59,16 @@ def home():
         row = cursor.fetchone()
         hashed_email = row[0] if row else ''
         conn.close()
-        body = urllib.parse.quote_plus(
-            f"Please remove my account. Email hash: {hashed_email}"
+        message = (
+            "Hello,\n\n"
+            "Please remove my account from Tolkar.se.\n"
+            f"Email hash: {hashed_email}\n\n"
+            "Regards,\n"
         )
+        body = urllib.parse.quote(message)
         removal_link = (
-            f"mailto:placeholder@tolkar.se?subject=Remove%20account&body={body}"
+            "mailto:placeholder@tolkar.se"
+            f"?subject=Account%20Deletion%20Request&body={body}"
         )
         return render_template(
             'home.html', bookings=bookings, removal_link=removal_link


### PR DESCRIPTION
## Summary
- Drop TOTP secret generation for the default test account
- Improve account deletion mailto link with a multi-line, URL-encoded message
- Update tests to match new test user configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0da9b5cb0832dbb7ba5ed4325a4b8