### PR TITLE
Add custom non-commercial hosting-restricted license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Custom Non-Commercial Hosting-Restricted License
+
+Copyright (c) 2024 Tolka
+
+Permission is granted to any person obtaining a copy of this software and associated documentation files (the "Software") to use, copy, and modify the Software for personal, non-commercial purposes only, subject to the following conditions:
+
+1. Non-Commercial Use
+   You may use the Software solely for non-commercial purposes. Any commercial use, including but not limited to generating revenue or providing paid services that rely on the Software, requires express written permission from the copyright holder.
+
+2. Hosting Restrictions
+   You may not host, deploy, or make the Software publicly accessible on any server, platform, or service, except with explicit permission from the copyright holder. The copyright holder reserves the exclusive right to host or authorize hosting of the Software.
+
+3. Redistribution
+   You may redistribute copies or modified versions of the Software only for non-commercial purposes and only if you include this license and copyright notice in full. Any distribution for commercial purposes requires prior written permission from the copyright holder.
+
+4. No Warranty
+   The Software is provided "as is," without warranty of any kind, express or implied. In no event shall the copyright holder be liable for any claim, damages, or other liability arising from the use or inability to use the Software.
+
+By using or distributing the Software, you acknowledge and agree to the terms of this license.
+


### PR DESCRIPTION
## Summary
- add custom license restricting commercial use and hosting rights to the owner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0dead6908832db39e3b1e0a8ea794