### PR TITLE
Add booking notifications and password recovery

### DIFF
--- a/static/style/auth.css
+++ b/static/style/auth.css
@@ -38,6 +38,14 @@ button:hover {
     color: red;
 }
 
+.info {
+    background-color: #ecf0f1;
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    color: #2c3e50;
+}
+
 /* Mobile-specific styles */
 @media (max-width: 768px) {
     input[type="text"],

--- a/static/style/dashboard.css
+++ b/static/style/dashboard.css
@@ -24,6 +24,12 @@
     background-color: #fafafa;
 }
 
+.dashboard-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 15px;
+}
+
 .dashboard-table th,
 .dashboard-table td {
     border: 1px solid #ddd;
@@ -77,6 +83,14 @@
     margin-right: 10px;
 }
 
+.dashboard-button.secondary {
+    background-color: #7f8c8d;
+}
+
+.dashboard-button.secondary:hover {
+    background-color: #707b7c;
+}
+
 .dashboard-button:hover {
     background-color: #2980b9;
 }
@@ -93,6 +107,17 @@
 .status-accepted {
     color: #27ae60;
     font-weight: bold;
+}
+
+.status-cancelled {
+    color: #c0392b;
+    font-weight: bold;
+}
+
+.dashboard-info {
+    margin: 10px 0 0;
+    font-size: 0.95rem;
+    color: #555;
 }
 
 @media (max-width: 600px) {

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Glömt lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Glömt lösenord</h1>
+<p>Ange den e-postadress som är kopplad till ditt konto så skickar vi instruktioner för att återställa lösenordet.</p>
+{% if message %}
+  <p class="info">{{ message }}</p>
+{% endif %}
+<form method="post">
+  <label for="email">E-post:</label>
+  <input type="email" id="email" name="email" required>
+  <input type="submit" value="Skicka instruktioner">
+</form>
+<p><a href="{{ url_for('user_login') }}">Tillbaka till inloggningen</a></p>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -12,7 +12,11 @@
   <img src="{{ url_for('static', filename='images/20250816_2214_Tolk och klient_simple_compose_01k2t86s2me5f9xgbccfde7gcg.png') }}" alt="Tolkar" class="home-hero">
   <div class="dashboard-container">
     <h1>Dina bokningar</h1>
+    <div class="dashboard-toolbar">
+      <button type="button" class="dashboard-button secondary" onclick="window.location.reload()">Uppdatera</button>
+    </div>
     {% if bookings %}
+    {% set ns = namespace(has_accepted=False) %}
     <div class="table-container">
       <table class="dashboard-table">
         <tr>
@@ -27,7 +31,16 @@
           <td>{{ b[1] }}</td>
           <td>{{ b[2] }}</td>
           <td>{{ b[3] }}</td>
-          <td class="status status-{{ b[4] }}">{{ b[4] }}</td>
+          <td class="status status-{{ b[4] }}">
+            {% if b[4] == 'accepted' %}
+              {% set ns.has_accepted = True %}
+              Accepted by {{ b[5] or 'okänd tolk' }} – {{ b[6] or 'okänt nummer' }}
+            {% elif b[4] == 'cancelled' %}
+              Avbruten
+            {% else %}
+              {{ b[4] }}
+            {% endif %}
+          </td>
           <td>
             {% if b[4] == 'pending' %}
             <form method="post" action="{{ url_for('cancel_booking', booking_id=b[0]) }}">
@@ -39,6 +52,9 @@
         {% endfor %}
       </table>
     </div>
+    {% if ns.has_accepted %}
+    <p class="dashboard-info">För avbokning av accepterade uppdrag, kontakta tolken minst 24 timmar i förväg.</p>
+    {% endif %}
     {% else %}
     <p>Du har inga bokningar.</p>
     {% endif %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,9 +12,13 @@
     {% if error %}
         <p class="error">{{ error }}</p>
     {% endif %}
+    <label for="name">Ditt namn:</label>
+    <input type="text" id="name" name="name" required value="{{ prefill_name or '' }}">
+    <label for="phone">Telefonnummer:</label>
+    <input type="tel" id="phone" name="phone" required value="{{ prefill_phone or '' }}">
     <label for="email">Email:</label>
-    <input type="email" id="email" name="email" required>
-    <label for="password">Password:</label>
+    <input type="email" id="email" name="email" required value="{{ prefill_email or '' }}">
+    <label for="password">Lösenord:</label>
     <input type="password" id="password" name="password" required>
     <input type="submit" value="Login">
 </form>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Återställ lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Återställ lösenord</h1>
+{% if success %}
+  <p class="info">Ditt lösenord har uppdaterats. <a href="{{ url_for('user_login') }}">Logga in</a>.</p>
+{% else %}
+  {% if error %}
+    <p class="error">{{ error }}</p>
+  {% else %}
+    <p>Ange ett nytt lösenord för ditt konto.</p>
+  {% endif %}
+  {% if token %}
+  <form method="post">
+    <label for="password">Nytt lösenord:</label>
+    <input type="password" id="password" name="password" required>
+    <label for="confirm_password">Bekräfta lösenord:</label>
+    <input type="password" id="confirm_password" name="confirm_password" required>
+    <input type="submit" value="Uppdatera lösenord">
+  </form>
+  {% endif %}
+{% endif %}
+<p><a href="{{ url_for('user_login') }}">Tillbaka till inloggningen</a></p>
+{% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -13,4 +13,5 @@
   <input type="password" id="password" name="password" required><br><br>
   <input type="submit" value="Logga in">
 </form>
+<p><a href="{{ url_for('forgot_password') }}">Glömt lösenord?</a></p>
 {% endblock %}

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -2,6 +2,7 @@
 import pytest
 import sqlite3
 import pyotp
+from datetime import datetime, timedelta
 import functions
 import website
 
@@ -200,7 +201,7 @@ def test_login_respects_application_root(monkeypatch):
         response = client.post(
             "/login",
             base_url="http://example.com/prefix",
-            data={"email": "e", "password": "secret"},
+            data={"email": "e", "password": "secret", "name": "Test", "phone": "0701234567"},
         )
 
         assert response.status_code == 302
@@ -336,7 +337,9 @@ def test_cancel_booking_updates_status(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT
         )
         """
     )
@@ -382,7 +385,9 @@ def test_confirmation_post_creates_booking(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT
         )
         """
     )
@@ -534,3 +539,113 @@ def test_two_factor_invalid_token_shows_error(client, tmp_path, monkeypatch):
     with client.session_transaction() as sess:
         assert "user_id" not in sess
         assert sess.get("pending_user_id") == user_id
+
+
+def test_forgot_password_creates_token(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    email = "reset@example.com"
+    pwd_hash, pwd_salt = functions.hash_password("secret")
+    email_hash, email_salt = functions.hash_email(email)
+    conn.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("Reset", email_hash, email_salt, "000", pwd_hash, pwd_salt),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post("/forgot_password", data={"email": email})
+    assert response.status_code == 200
+    assert "instruktioner" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute("SELECT token, expires_at FROM password_resets").fetchone()
+    conn.close()
+    assert row is not None
+    token, expires_at = row
+    assert token
+    assert datetime.fromisoformat(expires_at) > datetime.utcnow()
+
+
+def test_reset_password_updates_credentials(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE password_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+        )"""
+    )
+    conn.commit()
+
+    email = "user@example.com"
+    pwd_hash, pwd_salt = functions.hash_password("oldpass123")
+    email_hash, email_salt = functions.hash_email(email)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("User", email_hash, email_salt, "000", pwd_hash, pwd_salt),
+    )
+    user_id = cursor.lastrowid
+    token = "token123"
+    expires_at = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+    cursor.execute(
+        "INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)",
+        (user_id, token, expires_at),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        f"/reset_password/{token}",
+        data={"password": "newpassword", "confirm_password": "newpassword"},
+    )
+    assert response.status_code == 200
+    assert "uppdaterats" in response.get_data(as_text=True).lower()
+
+    conn = sqlite3.connect("database.db")
+    cursor = conn.cursor()
+    stored_hash, stored_salt = cursor.execute(
+        "SELECT password_hash, salt FROM logins WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    remaining = cursor.execute(
+        "SELECT COUNT(*) FROM password_resets WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()[0]
+    conn.close()
+
+    assert functions.verify_password("newpassword", stored_hash, stored_salt)
+    assert remaining == 0

--- a/website.py
+++ b/website.py
@@ -12,6 +12,7 @@ from itertools import combinations
 import subprocess
 import pyotp
 import urllib.parse
+import secrets
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -35,12 +36,115 @@ app.secret_key = functions.generate_secret_key()
 # Define the password for accessing the /jobs route
 PASSWORD = os.getenv('password')
 
+ORDER_EMAIL = "order@tolkar.se"
+CANCELLED_EMAIL = "cancelled@tolkar.se"
+ACCEPTED_EMAIL = "accepted@tolkar.se"
+
+
+def ensure_bookings_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            language TEXT NOT NULL,
+            time_start TEXT NOT NULL,
+            time_end TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            marking TEXT,
+            avtalskund_marking TEXT,
+            reference TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT
+        )
+        """
+    )
+    cursor.execute("PRAGMA table_info(bookings)")
+    columns = [info[1] for info in cursor.fetchall()]
+    if 'accepted_by_name' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN accepted_by_name TEXT")
+    if 'accepted_by_phone' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN accepted_by_phone TEXT")
+    conn.commit()
+
+
+def ensure_password_reset_table(conn):
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS password_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
+def send_email(recipients, subject, body):
+    if isinstance(recipients, str):
+        recipients = [recipients]
+    recipients = [r for r in recipients if r]
+    if not recipients:
+        return False
+
+    smtp_username = os.getenv("email")
+    smtp_password = os.getenv('Email_password')
+    smtp_server = os.getenv("smtp_server_address")
+    smtp_port = os.getenv("smtp_port")
+
+    if (
+        not smtp_username
+        or not smtp_password
+        or not smtp_server
+        or not smtp_port
+    ):
+        app.logger.warning("Email configuration missing. Skipping email send to %s", recipients)
+        return False
+
+    if app.config.get("TESTING"):
+        app.logger.debug("Testing mode – not sending email to %s", recipients)
+        return True
+
+    msg = MIMEMultipart()
+    msg['From'] = smtp_username
+    msg['To'] = ", ".join(recipients)
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+
+    bcc = smtp_username
+
+    try:
+        with smtplib.SMTP(smtp_server, int(smtp_port)) as server:
+            server.starttls()
+            server.login(smtp_username, smtp_password)
+            server.sendmail(
+                smtp_username,
+                recipients + [bcc],
+                msg.as_string(),
+            )
+        return True
+    except Exception as exc:
+        app.logger.error("Failed to send email to %s: %s", recipients, exc)
+        return False
+
 
 @app.route('/logout')
 def logout():
     session.pop('authenticated', None)
     session.pop('user_id', None)
     session.pop('user_email', None)
+    session.pop('tolkar_email', None)
+    session.pop('tolkar_name', None)
+    session.pop('tolkar_phone', None)
     return redirect(url_for('home'))
 
 
@@ -50,8 +154,12 @@ def home():
         user_email = session.get('user_email')
         conn = sqlite3.connect('database.db')
         cursor = conn.cursor()
+        ensure_bookings_schema(conn)
         cursor.execute(
-            "SELECT id, language, time_start, time_end, status FROM bookings WHERE email = ?",
+            """
+            SELECT id, language, time_start, time_end, status, accepted_by_name, accepted_by_phone
+            FROM bookings WHERE email = ?
+            """,
             (user_email,),
         )
         bookings = cursor.fetchall()
@@ -215,6 +323,7 @@ def get_jobs():
     # Connect to the database
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
+    ensure_bookings_schema(conn)
 
     # Retrieve pending jobs from the database
     cursor.execute("SELECT * FROM bookings WHERE status='pending' ORDER BY id ASC")
@@ -238,97 +347,89 @@ def accept_job(job_id):
     # Connect to the database
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
+    ensure_bookings_schema(conn)
 
     # Retrieve job information from the database
-    cursor.execute("SELECT name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference FROM bookings WHERE id = ?", (job_id,))
+    cursor.execute(
+        """
+        SELECT name, email, phone, language, time_start, time_end,
+               organization_number, billing_address, email_billing_address,
+               marking, avtalskund_marking, reference
+        FROM bookings WHERE id = ?
+        """,
+        (job_id,),
+    )
     job_data = cursor.fetchone()
 
+    tolkar_name = session.get('tolkar_name', '').strip()
+    tolkar_phone = session.get('tolkar_phone', '').strip()
+    tolkar_email = session.get('tolkar_email', '').strip()
+
+    if not job_data:
+        conn.close()
+        return "Jobb hittades inte", 404
+
+    if not tolkar_name or not tolkar_phone:
+        conn.close()
+        return "Tolkinformation saknas", 400
+
     # Mark the job as accepted instead of deleting
-    cursor.execute("UPDATE bookings SET status='accepted' WHERE id = ?", (job_id,))
+    cursor.execute(
+        "UPDATE bookings SET status='accepted', accepted_by_name=?, accepted_by_phone=? WHERE id = ?",
+        (tolkar_name, tolkar_phone, job_id),
+    )
     conn.commit()
 
     # Close the database connection
     cursor.close()
     conn.close()
-    def send_tolkar_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-        Kära Herr/Fru,
+    booking_summary = (
+        f"Kund: {job_data[0]}\n"
+        f"E-post: {job_data[1]}\n"
+        f"Telefon: {job_data[2]}\n"
+        f"Språk: {job_data[3]}\n"
+        f"Starttid: {job_data[4]}\n"
+        f"Sluttid: {job_data[5]}\n"
+    )
 
-        Här är bekräftelsen för jobb-ID: {job_id}.
+    translator_summary = f"Tolken: {tolkar_name} – {tolkar_phone}"
 
-        Namn: {job_data[0]}
-        E-post: {job_data[1]}
-        Telefonnummer: {job_data[2]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
+    send_email(
+        tolkar_email,
+        f"Bekräftelse – uppdrag {job_id}",
+        (
+            "Hej!\n\n"
+            "Du har accepterat följande uppdrag:\n\n"
+            f"{booking_summary}\n"
+            "Vänligen kontakta beställaren vid behov.\n\n"
+            "Hälsningar,\nTolkar.se"
+        ),
+    )
 
-        Vänligen granska sökandens kvalifikationer och referenser. Om du behöver ytterligare information eller har några frågor, vänligen kontakta sökanden direkt via det angivna e-postadressen eller telefonnumret.
+    send_email(
+        job_data[1],
+        f"Din bokning har accepterats (ID {job_id})",
+        (
+            "Hej!\n\n"
+            "Din bokning har accepterats av en tolk. Här är detaljerna:\n\n"
+            f"{booking_summary}"
+            f"{translator_summary}\n\n"
+            "Kontakta tolken direkt för eventuella ändringar eller avbokningar minst 24 timmar i förväg.\n\n"
+            "Hälsningar,\nTolkar.se"
+        ),
+    )
 
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
+    send_email(
+        ACCEPTED_EMAIL,
+        f"Bokning accepterad – ID {job_id}",
+        (
+            "En bokning har accepterats.\n\n"
+            f"{booking_summary}"
+            f"{translator_summary}\n"
+            f"Tolkens e-post: {tolkar_email}\n"
+        ),
+    )
 
-        Med vänliga hälsningar,
-        Tolkar-teamet"""   
-        # Prepare email message
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the session
-        msg['To'] = session.get('tolkar_email', '')  # Retrieve the email from the session
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain'))
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password') # Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = session.get('tolkar_email', '')  # Retrieve the recipient email from the session
-
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string())
-            
-            
-            
-    def send_user_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-                Kära Herr/Fru,
-
-        Din ansökan för jobb-ID: {job_id} har blivit accepterad.
-        
-        Om du inte har använt vår tjänst, vänligen kontakta oss.
-        Här är din information:   
-        Namn: {job_data[0]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
-        
-        
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
-        
-        
-        Med vänliga hälsningar,
-        Tolkar-teamet"""
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the .env file
-        msg['To'] = job_data[1] # Retrieving the email from the database
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain')) 
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password')# Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = job_data[1] # Retrieve the recipient email from the database
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string()) #Sending the mail
-    send_tolkar_email() # Running the function to send to the translation company
-    send_user_email() # Running the function to send to the user
     return 'Job accepted and email sent'
 
 
@@ -338,13 +439,47 @@ def cancel_booking(booking_id):
         return redirect(url_for('user_login'))
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
+    ensure_bookings_schema(conn)
     user_email = session.get('user_email')
+    cursor.execute(
+        """
+        SELECT id, name, email, phone, language, time_start, time_end
+        FROM bookings
+        WHERE id=? AND email=? AND status='pending'
+        """,
+        (booking_id, user_email),
+    )
+    booking = cursor.fetchone()
     cursor.execute(
         "UPDATE bookings SET status='cancelled' WHERE id=? AND email=? AND status='pending'",
         (booking_id, user_email),
     )
     conn.commit()
     conn.close()
+    if booking:
+        details = (
+            f"Kund: {booking[1]}\n"
+            f"E-post: {booking[2]}\n"
+            f"Telefon: {booking[3]}\n"
+            f"Språk: {booking[4]}\n"
+            f"Starttid: {booking[5]}\n"
+            f"Sluttid: {booking[6]}\n"
+        )
+        send_email(
+            CANCELLED_EMAIL,
+            f"Bokning avbruten – ID {booking[0]}",
+            "En bokning har avbrutits innan den accepterades.\n\n" + details,
+        )
+        send_email(
+            booking[2],
+            f"Bekräftelse på avbokning (ID {booking[0]})",
+            (
+                "Hej!\n\n"
+                "Din bokning har avbokats. Ingen tolk hade accepterat uppdraget.\n\n"
+                f"{details}"
+                "Hälsningar,\nTolkar.se"
+            ),
+        )
     return redirect(url_for('home'))
 
 @app.route('/submit', methods=['GET', 'POST'])
@@ -364,6 +499,10 @@ def submit():
     time_end = time_start + timedelta(minutes=time_end_minutes)
     time_start_str_trimmed = time_start.strftime('%Y-%m-%d %H:%M')
     time_end_str_trimmed = time_end.strftime('%Y-%m-%d %H:%M')
+
+    ensure_conn = sqlite3.connect('database.db')
+    ensure_bookings_schema(ensure_conn)
+    ensure_conn.close()
 
     if session.get('user_id'):
         conn = sqlite3.connect('database.db')
@@ -480,8 +619,16 @@ def confirmation():
             phone = session.get('phone')
             conn = sqlite3.connect('database.db')
             cursor = conn.cursor()
+            ensure_bookings_schema(conn)
             cursor.execute(
-                "INSERT INTO bookings (name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                """
+                INSERT INTO bookings (
+                    name, email, phone, language, time_start, time_end,
+                    organization_number, billing_address, email_billing_address,
+                    marking, avtalskund_marking, reference, status,
+                    accepted_by_name, accepted_by_phone
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
                 (
                     name,
                     email,
@@ -496,14 +643,46 @@ def confirmation():
                     '',
                     reference,
                     'pending',
+                    '',
+                    '',
                 ),
             )
+            booking_id = cursor.lastrowid
             conn.commit()
 
             # Close the database connection
             conn.close()
             time.sleep(1)
             session['submitted'] = False
+            booking_details = (
+                f"Boknings-ID: {booking_id}\n"
+                f"Namn: {name}\n"
+                f"E-post: {email}\n"
+                f"Telefon: {phone}\n"
+                f"Språk: {language}\n"
+                f"Starttid: {time_start}\n"
+                f"Sluttid: {time_end}\n"
+                f"Organisationsnummer: {organization_number}\n"
+                f"Fakturaadress: {billing_address}\n"
+                f"Faktura via e-post: {email_billing_address}\n"
+                f"Referens: {reference}\n"
+            )
+            send_email(
+                email,
+                "Din bokningsbekräftelse",
+                (
+                    "Hej!\n\n"
+                    "Tack för din bokning hos Tolkar.se. Här är en sammanfattning:\n\n"
+                    f"{booking_details}"
+                    "Vi kontaktar dig när en tolk har accepterat uppdraget.\n\n"
+                    "Hälsningar,\nTolkar.se"
+                ),
+            )
+            send_email(
+                ORDER_EMAIL,
+                f"Ny bokning mottagen – ID {booking_id}",
+                "En ny bokning har lagts.\n\n" + booking_details,
+            )
             if session.get('user_id'):
                 return redirect(url_for('home'))
             return redirect("https://www.tolkar.se/bekraftelse/")
@@ -515,14 +694,115 @@ def confirmation():
 def login():
     if request.method == 'POST':
         password = request.form['password']
+        tolkar_name = request.form.get('name', '').strip()
+        tolkar_phone = request.form.get('phone', '').strip()
+        tolkar_email = request.form.get('email', '').strip()
+        if not tolkar_name or not tolkar_phone:
+            return render_template('login.html', error='Namn och telefonnummer krävs.', prefill_email=tolkar_email, prefill_name=tolkar_name, prefill_phone=tolkar_phone)
         if password == PASSWORD:
             # Store the email in the session
-            session['tolkar_email'] = request.form['email']
+            session['tolkar_email'] = tolkar_email
+            session['tolkar_name'] = tolkar_name
+            session['tolkar_phone'] = tolkar_phone
             session['authenticated'] = True
             return redirect(url_for('get_jobs'))
         else:
-            return render_template('login.html', error='Invalid password')
-    return render_template('login.html')
+            return render_template('login.html', error='Felaktigt lösenord.', prefill_email=tolkar_email, prefill_name=tolkar_name, prefill_phone=tolkar_phone)
+    return render_template('login.html', prefill_email='', prefill_name='', prefill_phone='')
+
+
+@app.route('/forgot_password', methods=['GET', 'POST'])
+def forgot_password():
+    message = None
+    if request.method == 'POST':
+        email = request.form.get('email', '').strip().lower()
+        if not email:
+            message = 'Ange en giltig e-postadress.'
+        else:
+            conn = sqlite3.connect('database.db')
+            ensure_password_reset_table(conn)
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, email, email_salt FROM logins")
+            user_id = None
+            for row in cursor.fetchall():
+                candidate_id, email_hash, email_salt = row
+                if functions.verify_email(email, email_hash, email_salt):
+                    user_id = candidate_id
+                    break
+            if user_id is not None:
+                token = secrets.token_urlsafe(32)
+                expires_at = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+                cursor.execute("DELETE FROM password_resets WHERE user_id = ?", (user_id,))
+                cursor.execute(
+                    "INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)",
+                    (user_id, token, expires_at),
+                )
+                conn.commit()
+                reset_link = url_for('reset_password', token=token, _external=True)
+                send_email(
+                    email,
+                    'Återställning av lösenord',
+                    (
+                        "Hej!\n\n"
+                        "Vi har mottagit en begäran om att återställa ditt lösenord hos Tolkar.se."
+                        " Klicka på länken nedan för att välja ett nytt lösenord. Länken är giltig i en timme.\n\n"
+                        f"{reset_link}\n\n"
+                        "Om du inte har begärt detta kan du ignorera meddelandet.\n\n"
+                        "Hälsningar,\nTolkar.se"
+                    ),
+                )
+            conn.commit()
+            conn.close()
+            message = 'Om ett konto finns registrerat skickas instruktioner till e-postadressen.'
+        return render_template('forgot_password.html', message=message)
+    return render_template('forgot_password.html')
+
+
+@app.route('/reset_password/<token>', methods=['GET', 'POST'])
+def reset_password(token):
+    conn = sqlite3.connect('database.db')
+    ensure_password_reset_table(conn)
+    cursor = conn.cursor()
+    cursor.execute("SELECT user_id, expires_at FROM password_resets WHERE token = ?", (token,))
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return render_template('reset_password.html', error='Ogiltig eller utgången länk.', token=None)
+    user_id, expires_at_str = row
+    try:
+        expires_at = datetime.fromisoformat(expires_at_str)
+    except ValueError:
+        cursor.execute("DELETE FROM password_resets WHERE token = ?", (token,))
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', error='Ogiltig eller utgången länk.', token=None)
+    if datetime.utcnow() > expires_at:
+        cursor.execute("DELETE FROM password_resets WHERE token = ?", (token,))
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', error='Ogiltig eller utgången länk.', token=None)
+    if request.method == 'POST':
+        password = request.form.get('password', '')
+        confirm_password = request.form.get('confirm_password', '')
+        errors = []
+        if password != confirm_password:
+            errors.append('Lösenorden matchar inte.')
+        if len(password) < 8:
+            errors.append('Lösenordet måste vara minst 8 tecken.')
+        if errors:
+            conn.close()
+            return render_template('reset_password.html', error=' '.join(errors), token=token)
+        pwd_hash, salt = functions.hash_password(password)
+        cursor.execute(
+            "UPDATE logins SET password_hash = ?, salt = ? WHERE id = ?",
+            (pwd_hash, salt, user_id),
+        )
+        cursor.execute("DELETE FROM password_resets WHERE user_id = ?", (user_id,))
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', success=True)
+    conn.close()
+    return render_template('reset_password.html', token=token)
 
 @app.errorhandler(404)
 def page_not_found(e):
@@ -554,13 +834,19 @@ if __name__ == '__main__':
                     marking TEXT,
                     avtalskund_marking TEXT,
                     reference TEXT,
-                    status TEXT NOT NULL DEFAULT "pending")''')
+                    status TEXT NOT NULL DEFAULT "pending",
+                    accepted_by_name TEXT,
+                    accepted_by_phone TEXT)''')
 
     # Ensure the status column exists for older databases
     cursor.execute("PRAGMA table_info(bookings)")
     columns = [info[1] for info in cursor.fetchall()]
     if 'status' not in columns:
         cursor.execute("ALTER TABLE bookings ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+    if 'accepted_by_name' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN accepted_by_name TEXT")
+    if 'accepted_by_phone' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN accepted_by_phone TEXT")
 
     # Create the 'logins' table if it doesn't exist
     cursor.execute('''CREATE TABLE IF NOT EXISTS logins
@@ -589,6 +875,7 @@ if __name__ == '__main__':
         if col not in login_columns:
             cursor.execute(f"ALTER TABLE logins ADD COLUMN {col} TEXT")
 
+    ensure_password_reset_table(conn)
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- add booking schema management and email helpers to notify customers, interpreters, and back-office contacts for new, accepted, and cancelled jobs
- surface interpreter contact details and a manual refresh on the bookings dashboard with updated styling
- add a password reset flow with forgot/reset pages and accompanying tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c878be3758832d91212940eebc7d52