### PR TITLE
Add booking notifications, interpreter details, and password reset

### DIFF
--- a/static/style/dashboard.css
+++ b/static/style/dashboard.css
@@ -77,6 +77,16 @@
     margin-right: 10px;
 }
 
+.dashboard-refresh {
+    margin: 10px 0 20px 0;
+}
+
+.dashboard-refresh .dashboard-button {
+    margin-right: 0;
+    border: none;
+    cursor: pointer;
+}
+
 .dashboard-button:hover {
     background-color: #2980b9;
 }

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -65,20 +65,50 @@
 
     <script>
         function acceptJob(jobId) {
-            // Display loading overlay
+            const translatorName = prompt('Ange tolkens namn:');
+            if (translatorName === null) {
+                return;
+            }
+            const trimmedName = translatorName.trim();
+            if (!trimmedName) {
+                alert('Du måste ange ett namn för tolken.');
+                return;
+            }
+
+            const translatorPhone = prompt('Ange tolkens telefonnummer:');
+            if (translatorPhone === null) {
+                return;
+            }
+            const trimmedPhone = translatorPhone.trim();
+            if (!trimmedPhone) {
+                alert('Du måste ange ett telefonnummer.');
+                return;
+            }
+
             document.getElementById('loadingOverlay').style.display = 'flex';
 
-            fetch(`/jobs/${jobId}`, { method: 'POST' })
-                .then(response => {
-                    // Hide loading overlay when the request is complete
+            fetch(`/jobs/${jobId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    translator_name: trimmedName,
+                    translator_phone: trimmedPhone
+                })
+            })
+                .then(async response => {
+                    const data = await response.json().catch(() => ({}));
                     document.getElementById('loadingOverlay').style.display = 'none';
 
                     if (response.ok) {
-                        alert('Job accepted and mail sent!');
-                        location.reload();  // Refresh the page to update the job list
+                        alert('Uppdrag accepterat!');
+                        location.reload();
                     } else {
-                        alert('Failed to accept the job. Please refresh the page.');
+                        alert(data.error || 'Kunde inte acceptera uppdraget. Försök igen.');
                     }
+                })
+                .catch(() => {
+                    document.getElementById('loadingOverlay').style.display = 'none';
+                    alert('Ett fel uppstod. Försök igen.');
                 });
         }
     </script>

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Glömt lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Glömt lösenord</h1>
+{% if submitted %}
+<p>Om e-postadressen finns registrerad skickar vi en återställningslänk inom kort.</p>
+<a href="{{ url_for('user_login') }}">Tillbaka till inloggning</a>
+{% else %}
+<form action="{{ url_for('forgot_password') }}" method="post">
+  <label for="email">E-postadress</label>
+  <input type="email" id="email" name="email" required>
+  <input type="submit" value="Skicka återställningslänk">
+</form>
+<a href="{{ url_for('user_login') }}">Tillbaka</a>
+{% endif %}
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,13 +10,16 @@
 {% if bookings is defined %}
 <div class="home-hero-container">
   <img src="{{ url_for('static', filename='images/20250816_2214_Tolk och klient_simple_compose_01k2t86s2me5f9xgbccfde7gcg.png') }}" alt="Tolkar" class="home-hero">
-  <div class="dashboard-container">
-    <h1>Dina bokningar</h1>
-    {% if bookings %}
-    <div class="table-container">
-      <table class="dashboard-table">
-        <tr>
-          <th>Språk</th>
+    <div class="dashboard-container">
+      <h1>Dina bokningar</h1>
+      <form method="get" action="{{ url_for('home') }}" class="dashboard-refresh">
+        <button type="submit" class="dashboard-button">Uppdatera</button>
+      </form>
+      {% if bookings %}
+      <div class="table-container">
+        <table class="dashboard-table">
+          <tr>
+            <th>Språk</th>
           <th>Starttid</th>
           <th>Sluttid</th>
           <th>Status</th>
@@ -27,7 +30,15 @@
           <td>{{ b[1] }}</td>
           <td>{{ b[2] }}</td>
           <td>{{ b[3] }}</td>
-          <td class="status status-{{ b[4] }}">{{ b[4] }}</td>
+          <td class="status status-{{ b[4] }}">
+            {% if b[4] == 'accepted' and b[5] and b[6] %}
+            Accepted by {{ b[5] }} – {{ b[6] }}
+            {% elif b[4] == 'cancelled' %}
+            Cancelled
+            {% else %}
+            {{ b[4] }}
+            {% endif %}
+          </td>
           <td>
             {% if b[4] == 'pending' %}
             <form method="post" action="{{ url_for('cancel_booking', booking_id=b[0]) }}">
@@ -38,10 +49,10 @@
         </tr>
         {% endfor %}
       </table>
-    </div>
-    {% else %}
-    <p>Du har inga bokningar.</p>
-    {% endif %}
+      </div>
+      {% else %}
+      <p>Du har inga bokningar.</p>
+      {% endif %}
     <div class="dashboard-actions">
       <a href="{{ url_for('index') }}" class="dashboard-button">Gör ny bokning</a>
       <a href="{{ url_for('logout') }}" class="dashboard-button">Logga ut</a>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Återställ lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Återställ lösenord</h1>
+{% if invalid %}
+<p class="error">Länken är ogiltig eller har redan använts.</p>
+<a href="{{ url_for('forgot_password') }}">Begär ny länk</a>
+{% elif expired %}
+<p class="error">Länken har löpt ut. Begär en ny återställning.</p>
+<a href="{{ url_for('forgot_password') }}">Begär ny länk</a>
+{% elif success %}
+<p>Ditt lösenord har uppdaterats. Du kan nu <a href="{{ url_for('user_login') }}">logga in</a>.</p>
+{% elif token_valid %}
+  {% if error %}
+  <p class="error">{{ error }}</p>
+  {% endif %}
+  <form action="{{ url_for('reset_password', token=token) }}" method="post">
+    <label for="password">Nytt lösenord</label>
+    <input type="password" id="password" name="password" required>
+    <label for="confirm_password">Bekräfta lösenord</label>
+    <input type="password" id="confirm_password" name="confirm_password" required>
+    <input type="submit" value="Spara nytt lösenord">
+  </form>
+{% else %}
+<p class="error">Länken kunde inte verifieras.</p>
+<a href="{{ url_for('forgot_password') }}">Begär ny länk</a>
+{% endif %}
+{% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -13,4 +13,5 @@
   <input type="password" id="password" name="password" required><br><br>
   <input type="submit" value="Logga in">
 </form>
+<p><a href="{{ url_for('forgot_password') }}">Glömt lösenord?</a></p>
 {% endblock %}

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -46,7 +46,9 @@ def setup_logins_db(tmp_path):
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )
         """,
     )

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -4,6 +4,8 @@ import sqlite3
 import pyotp
 import functions
 import website
+from datetime import datetime, timedelta
+import hashlib
 
 
 @pytest.fixture
@@ -63,7 +65,9 @@ def test_user_login_without_2fa_redirects_home(client):
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )"""
     )
     conn.commit()
@@ -105,7 +109,9 @@ def test_user_login_with_2fa_redirects_two_factor(client):
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )"""
     )
     conn.commit()
@@ -148,7 +154,9 @@ def test_two_factor_secret_not_shown_on_login(client):
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )"""
     )
     conn.commit()
@@ -336,6 +344,8 @@ def test_cancel_booking_updates_status(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT,
             status TEXT NOT NULL DEFAULT 'pending'
         )
         """
@@ -382,6 +392,8 @@ def test_confirmation_post_creates_booking(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT,
             status TEXT NOT NULL DEFAULT 'pending'
         )
         """
@@ -429,7 +441,9 @@ def test_user_login_invalid_credentials_shows_error(client, tmp_path, monkeypatc
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )"""
     )
     conn.commit()
@@ -458,7 +472,9 @@ def test_two_factor_valid_token_authenticates_user(client, tmp_path, monkeypatch
             organization_number TEXT,
             billing_address TEXT,
             email_billing_address TEXT,
-            totp_secret TEXT
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
         )"""
     )
     conn.commit()
@@ -534,3 +550,242 @@ def test_two_factor_invalid_token_shows_error(client, tmp_path, monkeypatch):
     with client.session_transaction() as sess:
         assert "user_id" not in sess
         assert sess.get("pending_user_id") == user_id
+
+
+def test_home_shows_accepted_contact_info(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            language TEXT NOT NULL,
+            time_start TEXT NOT NULL,
+            time_end TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            marking TEXT,
+            avtalskund_marking TEXT,
+            reference TEXT,
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT,
+            status TEXT NOT NULL DEFAULT 'pending'
+        )"""
+    )
+    conn.commit()
+
+    email = "user@example.com"
+    pwd_hash, pwd_salt = functions.hash_password("secret")
+    email_hash, email_salt = functions.hash_email(email)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret, reset_token_hash, reset_token_expiry) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '', NULL, NULL)",
+        ("User", email_hash, email_salt, "070", pwd_hash, pwd_salt),
+    )
+    user_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO bookings (name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference, accepted_by_name, accepted_by_phone, status) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '', '', '', ?, ?, 'accepted')",
+        ("User", email, "070", "English", "2024-09-01 10:00", "2024-09-01 11:00", "Tolken", "070-123"),
+    )
+    conn.commit()
+    conn.close()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["user_email"] = email
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Accepted by Tolken – 070-123" in response.get_data(as_text=True)
+
+
+def test_accept_job_updates_booking(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            language TEXT NOT NULL,
+            time_start TEXT NOT NULL,
+            time_end TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            marking TEXT,
+            avtalskund_marking TEXT,
+            reference TEXT,
+            accepted_by_name TEXT,
+            accepted_by_phone TEXT,
+            status TEXT NOT NULL DEFAULT 'pending'
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO bookings (name, email, phone, language, time_start, time_end, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')",
+        ("Customer", "customer@example.com", "070", "English", "2024-09-01 10:00", "2024-09-01 11:00"),
+    )
+    booking_id = conn.execute("SELECT id FROM bookings").fetchone()[0]
+    conn.commit()
+    conn.close()
+
+    sent_messages = []
+
+    def fake_send_email(subject, body, to_addresses, bcc=None):
+        sent_messages.append((subject, body, to_addresses))
+        return True
+
+    monkeypatch.setattr(website, "send_email", fake_send_email)
+
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True
+        sess["tolkar_email"] = "agency@example.com"
+
+    response = client.post(
+        f"/jobs/{booking_id}",
+        json={"translator_name": "Tolken", "translator_phone": "070-123"},
+    )
+    assert response.status_code == 200
+    assert response.is_json
+    assert response.get_json()["message"] == "Job accepted"
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute(
+        "SELECT status, accepted_by_name, accepted_by_phone FROM bookings WHERE id = ?",
+        (booking_id,),
+    ).fetchone()
+    conn.close()
+    assert row == ("accepted", "Tolken", "070-123")
+    assert len(sent_messages) == 3
+
+
+def test_forgot_password_generates_token(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
+        )"""
+    )
+    conn.commit()
+    email = "reset@example.com"
+    email_hash, email_salt = functions.hash_email(email)
+    conn.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret, reset_token_hash, reset_token_expiry) VALUES (?, ?, ?, ?, '', '', '', '', '', '', NULL, NULL)",
+        ("Reset User", email_hash, email_salt, "070"),
+    )
+    conn.commit()
+    conn.close()
+
+    sent = {}
+
+    def fake_send_email(subject, body, to_addresses, bcc=None):
+        sent["subject"] = subject
+        sent["body"] = body
+        sent["to"] = to_addresses
+        return True
+
+    monkeypatch.setattr(website, "send_email", fake_send_email)
+
+    response = client.post("/forgot_password", data={"email": email})
+    assert response.status_code == 200
+    assert "återställningslänk" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute(
+        "SELECT reset_token_hash, reset_token_expiry FROM logins WHERE email = ?",
+        (email_hash,),
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    token_hash, token_expiry = row
+    assert token_hash is not None
+    assert token_expiry is not None
+    assert sent["to"] == email
+
+
+def test_reset_password_updates_password(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT,
+            reset_token_hash TEXT,
+            reset_token_expiry TEXT
+        )"""
+    )
+    conn.commit()
+    email = "reset2@example.com"
+    password_hash, password_salt = functions.hash_password("oldpass")
+    email_hash, email_salt = functions.hash_email(email)
+    token = "token123"
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    expiry = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+    conn.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret, reset_token_hash, reset_token_expiry) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '', ?, ?)",
+        ("Reset", email_hash, email_salt, "070", password_hash, password_salt, token_hash, expiry),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        f"/reset_password/{token}",
+        data={"password": "newpass", "confirm_password": "newpass"},
+    )
+    assert response.status_code == 200
+    assert "Ditt lösenord har uppdaterats" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute(
+        "SELECT password_hash, salt, reset_token_hash, reset_token_expiry FROM logins WHERE email = ?",
+        (email_hash,),
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    new_hash, new_salt, stored_token, stored_expiry = row
+    assert stored_token is None
+    assert stored_expiry is None
+    assert functions.verify_password("newpass", new_hash, new_salt)

--- a/website.py
+++ b/website.py
@@ -12,6 +12,8 @@ from itertools import combinations
 import subprocess
 import pyotp
 import urllib.parse
+import secrets
+import hashlib
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -35,6 +37,48 @@ app.secret_key = functions.generate_secret_key()
 # Define the password for accessing the /jobs route
 PASSWORD = os.getenv('password')
 
+ORDER_INBOX = "order@tolkar.se"
+ACCEPTED_INBOX = "accepted@tolkar.se"
+CANCELLED_INBOX = "cancelled@tolkar.se"
+
+
+def send_email(subject, body, to_addresses, bcc=None):
+    """Send an email and fail silently if configuration is missing."""
+
+    if isinstance(to_addresses, str):
+        to_addresses = [to_addresses]
+    if isinstance(bcc, str):
+        bcc = [bcc]
+
+    to_addresses = [addr for addr in (to_addresses or []) if addr]
+    bcc = [addr for addr in (bcc or []) if addr]
+
+    smtp_username = os.getenv("email")
+    smtp_password = os.getenv('Email_password')
+    smtp_server = os.getenv("smtp_server_address")
+    smtp_port = os.getenv("smtp_port")
+
+    if not to_addresses or not smtp_username or not smtp_password or not smtp_server or not smtp_port:
+        return False
+
+    msg = MIMEMultipart()
+    msg['From'] = smtp_username
+    msg['To'] = ", ".join(to_addresses)
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+    if bcc:
+        msg['Bcc'] = ", ".join(bcc)
+
+    try:
+        with smtplib.SMTP(smtp_server, int(smtp_port)) as server:
+            server.starttls()
+            server.login(smtp_username, smtp_password)
+            server.sendmail(smtp_username, to_addresses + bcc, msg.as_string())
+        return True
+    except Exception as exc:  # pragma: no cover - avoid failing hard in prod
+        print(f"Failed to send email: {exc}")
+        return False
+
 
 @app.route('/logout')
 def logout():
@@ -51,7 +95,12 @@ def home():
         conn = sqlite3.connect('database.db')
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, language, time_start, time_end, status FROM bookings WHERE email = ?",
+            """
+            SELECT id, language, time_start, time_end, status, accepted_by_name, accepted_by_phone
+            FROM bookings
+            WHERE email = ?
+            ORDER BY time_start DESC
+            """,
             (user_email,),
         )
         bookings = cursor.fetchall()
@@ -230,106 +279,112 @@ def get_jobs():
 
 @app.route('/jobs/<int:job_id>', methods=['POST']) # The action to accept the job
 def accept_job(job_id):
-    print(job_id)
-    # Check if the user is authenticated
     if 'authenticated' not in session:
-        return render_template('login.html')
+        return render_template('login.html'), 401
 
-    # Connect to the database
+    data = request.get_json(silent=True) or {}
+    translator_name = data.get('translator_name', '').strip()
+    translator_phone = data.get('translator_phone', '').strip()
+
+    if not translator_name or not translator_phone:
+        return {"error": "Translator name and phone are required."}, 400
+
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
 
-    # Retrieve job information from the database
-    cursor.execute("SELECT name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference FROM bookings WHERE id = ?", (job_id,))
-    job_data = cursor.fetchone()
+    cursor.execute(
+        """
+        SELECT name, email, phone, language, time_start, time_end, organization_number,
+               billing_address, email_billing_address, marking, avtalskund_marking, reference, status
+        FROM bookings WHERE id = ?
+        """,
+        (job_id,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return {"error": "Booking not found."}, 404
 
-    # Mark the job as accepted instead of deleting
-    cursor.execute("UPDATE bookings SET status='accepted' WHERE id = ?", (job_id,))
+    (*customer_data, status) = row
+    if status != 'pending':
+        conn.close()
+        return {"error": "Booking already processed."}, 400
+
+    cursor.execute(
+        """
+        UPDATE bookings
+        SET status='accepted', accepted_by_name=?, accepted_by_phone=?
+        WHERE id=? AND status='pending'
+        """,
+        (translator_name, translator_phone, job_id),
+    )
     conn.commit()
-
-    # Close the database connection
-    cursor.close()
     conn.close()
-    def send_tolkar_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-        Kära Herr/Fru,
 
-        Här är bekräftelsen för jobb-ID: {job_id}.
+    job_info = {
+        "name": customer_data[0],
+        "email": customer_data[1],
+        "phone": customer_data[2],
+        "language": customer_data[3],
+        "time_start": customer_data[4],
+        "time_end": customer_data[5],
+        "organization_number": customer_data[6],
+        "billing_address": customer_data[7],
+        "email_billing_address": customer_data[8],
+        "marking": customer_data[9],
+        "avtalskund_marking": customer_data[10],
+        "reference": customer_data[11],
+    }
 
-        Namn: {job_data[0]}
-        E-post: {job_data[1]}
-        Telefonnummer: {job_data[2]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
+    translator_email = session.get('tolkar_email', '')
+    subject = f"Bokning #{job_id} accepterad"
 
-        Vänligen granska sökandens kvalifikationer och referenser. Om du behöver ytterligare information eller har några frågor, vänligen kontakta sökanden direkt via det angivna e-postadressen eller telefonnumret.
+    translator_body = f"""
+Hej,
 
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
+Du har accepterat bokningen #{job_id}.
 
-        Med vänliga hälsningar,
-        Tolkar-teamet"""   
-        # Prepare email message
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the session
-        msg['To'] = session.get('tolkar_email', '')  # Retrieve the email from the session
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain'))
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password') # Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = session.get('tolkar_email', '')  # Retrieve the recipient email from the session
+Kund: {job_info['name']} ({job_info['email']}, {job_info['phone']})
+Språk: {job_info['language']}
+Starttid: {job_info['time_start']}
+Sluttid: {job_info['time_end']}
 
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string())
-            
-            
-            
-    def send_user_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-                Kära Herr/Fru,
+Tolk: {translator_name} – {translator_phone}
 
-        Din ansökan för jobb-ID: {job_id} har blivit accepterad.
-        
-        Om du inte har använt vår tjänst, vänligen kontakta oss.
-        Här är din information:   
-        Namn: {job_data[0]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
-        
-        
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
-        
-        
-        Med vänliga hälsningar,
-        Tolkar-teamet"""
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the .env file
-        msg['To'] = job_data[1] # Retrieving the email from the database
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain')) 
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password')# Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = job_data[1] # Retrieve the recipient email from the database
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string()) #Sending the mail
-    send_tolkar_email() # Running the function to send to the translation company
-    send_user_email() # Running the function to send to the user
-    return 'Job accepted and email sent'
+Kom ihåg att kontakta kunden vid eventuella ändringar.
+
+Vänliga hälsningar,
+Tolkar.se
+"""
+    user_body = f"""
+Hej {job_info['name']},
+
+Din bokning #{job_id} har accepterats av {translator_name} – {translator_phone}.
+
+Du kan kontakta tolken direkt vid ändringar eller avbokning. Enligt villkoren behöver avbokning ske minst 24 timmar innan start.
+
+Detaljer:
+Språk: {job_info['language']}
+Starttid: {job_info['time_start']}
+Sluttid: {job_info['time_end']}
+
+Tack för att du använder Tolkar.se!
+"""
+    admin_body = f"""
+Bokning #{job_id} har accepterats.
+
+Kund: {job_info['name']} ({job_info['email']}, {job_info['phone']})
+Språk: {job_info['language']}
+Starttid: {job_info['time_start']}
+Sluttid: {job_info['time_end']}
+Tolk: {translator_name} – {translator_phone}
+"""
+
+    send_email(subject, translator_body, translator_email)
+    send_email(subject, user_body, job_info['email'])
+    send_email(subject, admin_body, ACCEPTED_INBOX)
+
+    return {"message": "Job accepted"}
 
 
 @app.route('/cancel_booking/<int:booking_id>', methods=['POST'])
@@ -340,11 +395,45 @@ def cancel_booking(booking_id):
     cursor = conn.cursor()
     user_email = session.get('user_email')
     cursor.execute(
+        "SELECT name, language, time_start, time_end, status, phone FROM bookings WHERE id=? AND email=?",
+        (booking_id, user_email),
+    )
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return redirect(url_for('home'))
+
+    name, language, time_start, time_end, status, phone = row
+    if status != 'pending':
+        conn.close()
+        return redirect(url_for('home'))
+
+    cursor.execute(
         "UPDATE bookings SET status='cancelled' WHERE id=? AND email=? AND status='pending'",
         (booking_id, user_email),
     )
     conn.commit()
     conn.close()
+
+    subject = f"Bokning #{booking_id} avbokad"
+    body = f"""
+Hej {name},
+
+Din bokning #{booking_id} för {language} den {time_start} - {time_end} har avbokats.
+
+Om detta skedde av misstag kan du göra en ny bokning via Tolkar.se.
+"""
+    admin_body = f"""
+Bokning #{booking_id} har avbokats av kunden.
+
+Kund: {name} ({user_email}, {phone})
+Språk: {language}
+Starttid: {time_start}
+Sluttid: {time_end}
+"""
+
+    send_email(subject, body, user_email)
+    send_email(subject, admin_body, CANCELLED_INBOX)
     return redirect(url_for('home'))
 
 @app.route('/submit', methods=['GET', 'POST'])
@@ -498,10 +587,39 @@ def confirmation():
                     'pending',
                 ),
             )
+            booking_id = cursor.lastrowid
             conn.commit()
 
             # Close the database connection
             conn.close()
+
+            subject = f"Bekräftelse bokning #{booking_id}"
+            body = f"""
+Hej {name},
+
+Tack för din bokning hos Tolkar.se. Här är en sammanställning av uppdraget:
+
+Språk: {language}
+Starttid: {time_start}
+Sluttid: {time_end}
+Telefon: {phone}
+
+Du kan avboka via ditt konto så länge ingen tolk har accepterat uppdraget. När en tolk är bokad kontaktar du tolken direkt.
+
+Vi återkommer så snart någon accepterar uppdraget.
+"""
+            admin_body = f"""
+Ny bokning #{booking_id} har skapats.
+
+Kund: {name} ({email}, {phone})
+Språk: {language}
+Starttid: {time_start}
+Sluttid: {time_end}
+Referens: {reference or '-'}
+"""
+
+            send_email(subject, body, email)
+            send_email(f"Ny bokning #{booking_id}", admin_body, ORDER_INBOX)
             time.sleep(1)
             session['submitted'] = False
             if session.get('user_id'):
@@ -523,6 +641,98 @@ def login():
         else:
             return render_template('login.html', error='Invalid password')
     return render_template('login.html')
+
+
+@app.route('/forgot_password', methods=['GET', 'POST'])
+def forgot_password():
+    if request.method == 'POST':
+        email_input = request.form['email']
+        conn = sqlite3.connect('database.db')
+        cursor = conn.cursor()
+        cursor.execute('SELECT id, email, email_salt FROM logins')
+        user_row = None
+        for user_id, email_hash, email_salt in cursor.fetchall():
+            if functions.verify_email(email_input, email_hash, email_salt):
+                user_row = (user_id, email_input)
+                break
+
+        if user_row:
+            user_id, plain_email = user_row
+            token = secrets.token_urlsafe(32)
+            token_hash = hashlib.sha256(token.encode()).hexdigest()
+            expiry = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+            cursor.execute(
+                'UPDATE logins SET reset_token_hash=?, reset_token_expiry=? WHERE id=?',
+                (token_hash, expiry, user_id),
+            )
+            conn.commit()
+            reset_path = url_for('reset_password', token=token)
+            reset_link = request.url_root.rstrip('/') + reset_path
+            body = f"""
+Hej,
+
+Vi har tagit emot en begäran om att återställa ditt lösenord på Tolkar.se.
+
+Använd länken nedan för att ange ett nytt lösenord. Länken är giltig i en timme.
+{reset_link}
+
+Om du inte har begärt återställning kan du ignorera detta meddelande.
+"""
+            send_email('Återställ ditt lösenord', body, plain_email)
+
+        conn.close()
+        return render_template('forgot_password.html', submitted=True)
+
+    return render_template('forgot_password.html')
+
+
+@app.route('/reset_password/<token>', methods=['GET', 'POST'])
+def reset_password(token):
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    conn = sqlite3.connect('database.db')
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT id, reset_token_expiry FROM logins WHERE reset_token_hash = ?',
+        (token_hash,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return render_template('reset_password.html', invalid=True), 404
+
+    user_id, expiry = row
+    try:
+        expiry_dt = datetime.fromisoformat(expiry)
+    except (TypeError, ValueError):
+        expiry_dt = datetime.utcnow() - timedelta(seconds=1)
+
+    if datetime.utcnow() > expiry_dt:
+        cursor.execute(
+            'UPDATE logins SET reset_token_hash=NULL, reset_token_expiry=NULL WHERE id=?',
+            (user_id,),
+        )
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', expired=True), 400
+
+    if request.method == 'POST':
+        password = request.form['password']
+        confirm_password = request.form['confirm_password']
+        if password != confirm_password:
+            conn.close()
+            return render_template('reset_password.html', token=token, error='Lösenorden matchar inte.', token_valid=True)
+
+        pwd_hash, pwd_salt = functions.hash_password(password)
+        cursor.execute(
+            'UPDATE logins SET password_hash=?, salt=?, reset_token_hash=NULL, reset_token_expiry=NULL WHERE id=?',
+            (pwd_hash, pwd_salt, user_id),
+        )
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', success=True)
+
+    conn.close()
+    return render_template('reset_password.html', token=token, token_valid=True)
 
 @app.errorhandler(404)
 def page_not_found(e):
@@ -554,6 +764,8 @@ if __name__ == '__main__':
                     marking TEXT,
                     avtalskund_marking TEXT,
                     reference TEXT,
+                    accepted_by_name TEXT,
+                    accepted_by_phone TEXT,
                     status TEXT NOT NULL DEFAULT "pending")''')
 
     # Ensure the status column exists for older databases
@@ -561,6 +773,9 @@ if __name__ == '__main__':
     columns = [info[1] for info in cursor.fetchall()]
     if 'status' not in columns:
         cursor.execute("ALTER TABLE bookings ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+    for col in ('accepted_by_name', 'accepted_by_phone'):
+        if col not in columns:
+            cursor.execute(f"ALTER TABLE bookings ADD COLUMN {col} TEXT")
 
     # Create the 'logins' table if it doesn't exist
     cursor.execute('''CREATE TABLE IF NOT EXISTS logins
@@ -574,7 +789,9 @@ if __name__ == '__main__':
                     organization_number TEXT,
                     billing_address TEXT,
                     email_billing_address TEXT,
-                    totp_secret TEXT)''')
+                    totp_secret TEXT,
+                    reset_token_hash TEXT,
+                    reset_token_expiry TEXT)''')
 
     cursor.execute("PRAGMA table_info(logins)")
     login_columns = [info[1] for info in cursor.fetchall()]
@@ -584,6 +801,8 @@ if __name__ == '__main__':
         'email_billing_address',
         'email_salt',
         'totp_secret',
+        'reset_token_hash',
+        'reset_token_expiry',
     ]
     for col in extra_cols:
         if col not in login_columns:


### PR DESCRIPTION
## Summary
- add reusable email helper and trigger notifications for new, accepted, and cancelled bookings
- store interpreter contact info when accepting a job and surface it on the customer dashboard with a refresh action
- implement customer password reset flow and accompanying UI updates and tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c878be3758832d91212940eebc7d52