### PR TITLE
Add booking notifications and forgot password support

### DIFF
--- a/static/style/auth.css
+++ b/static/style/auth.css
@@ -38,6 +38,10 @@ button:hover {
     color: red;
 }
 
+.success {
+    color: #27ae60;
+}
+
 /* Mobile-specific styles */
 @media (max-width: 768px) {
     input[type="text"],

--- a/static/style/dashboard.css
+++ b/static/style/dashboard.css
@@ -13,6 +13,13 @@
     z-index: 1;
 }
 
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
 .table-container {
     overflow-x: auto;
 }
@@ -75,6 +82,8 @@
     text-decoration: none;
     border-radius: 4px;
     margin-right: 10px;
+    border: none;
+    cursor: pointer;
 }
 
 .dashboard-button:hover {
@@ -92,6 +101,11 @@
 
 .status-accepted {
     color: #27ae60;
+    font-weight: bold;
+}
+
+.status-cancelled {
+    color: #c0392b;
     font-weight: bold;
 }
 
@@ -115,5 +129,11 @@
         margin-right: 0;
         width: 100%;
         text-align: center;
+    }
+
+    .dashboard-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
     }
 }

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Glömt lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Glömt lösenord</h1>
+<p>Ange din e-postadress så skickar vi ett temporärt lösenord om kontot finns registrerat.</p>
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
+{% if message %}
+<p class="success">{{ message }}</p>
+{% endif %}
+<form action="{{ url_for('forgot_password') }}" method="POST">
+  <label for="email">Email:</label>
+  <input type="email" id="email" name="email" required>
+  <input type="submit" value="Skicka nytt lösenord">
+</form>
+<p><a href="{{ url_for('login') }}">Tillbaka till tolklogin</a></p>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,7 +11,10 @@
 <div class="home-hero-container">
   <img src="{{ url_for('static', filename='images/20250816_2214_Tolk och klient_simple_compose_01k2t86s2me5f9xgbccfde7gcg.png') }}" alt="Tolkar" class="home-hero">
   <div class="dashboard-container">
-    <h1>Dina bokningar</h1>
+    <div class="dashboard-header">
+      <h1>Dina bokningar</h1>
+      <button type="button" class="dashboard-button" onclick="window.location.reload()">Uppdatera</button>
+    </div>
     {% if bookings %}
     <div class="table-container">
       <table class="dashboard-table">
@@ -22,15 +25,23 @@
           <th>Status</th>
           <th></th>
         </tr>
-        {% for b in bookings %}
+        {% for booking in bookings %}
         <tr>
-          <td>{{ b[1] }}</td>
-          <td>{{ b[2] }}</td>
-          <td>{{ b[3] }}</td>
-          <td class="status status-{{ b[4] }}">{{ b[4] }}</td>
+          <td>{{ booking.language }}</td>
+          <td>{{ booking.time_start }}</td>
+          <td>{{ booking.time_end }}</td>
+          <td class="status status-{{ booking.status }}">
+            {% if booking.status == 'accepted' %}
+              Accepted by {{ booking.interpreter_name or 'Unknown interpreter' }} – {{ booking.interpreter_phone or 'No phone' }}
+            {% elif booking.status == 'cancelled' %}
+              Cancelled
+            {% else %}
+              Pending
+            {% endif %}
+          </td>
           <td>
-            {% if b[4] == 'pending' %}
-            <form method="post" action="{{ url_for('cancel_booking', booking_id=b[0]) }}">
+            {% if booking.status == 'pending' %}
+            <form method="post" action="{{ url_for('cancel_booking', booking_id=booking.id) }}">
               <button type="submit" class="cancel-button">Avbryt</button>
             </form>
             {% endif %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,11 +12,17 @@
     {% if error %}
         <p class="error">{{ error }}</p>
     {% endif %}
+    <label for="name">Namn:</label>
+    <input type="text" id="name" name="name" value="{{ name|default('') }}" required>
     <label for="email">Email:</label>
-    <input type="email" id="email" name="email" required>
+    <input type="email" id="email" name="email" value="{{ email|default('') }}" required>
+    <label for="phone">Telefon:</label>
+    <input type="tel" id="phone" name="phone" value="{{ phone|default('') }}" required>
     <label for="password">Password:</label>
     <input type="password" id="password" name="password" required>
     <input type="submit" value="Login">
 </form>
+
+<p><a href="{{ url_for('forgot_password') }}">Glömt lösenord?</a></p>
 
 {% endblock %}

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -200,11 +200,16 @@ def test_login_respects_application_root(monkeypatch):
         response = client.post(
             "/login",
             base_url="http://example.com/prefix",
-            data={"email": "e", "password": "secret"},
+            data={
+                "email": "e",
+                "password": "secret",
+                "name": "Interpreter",
+                "phone": "0700000000",
+            },
         )
 
-        assert response.status_code == 302
-        assert response.headers["Location"] == "/prefix/jobs"
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/prefix/jobs"
 
     website.PASSWORD = old_password
     app.config["APPLICATION_ROOT"] = "/"
@@ -336,7 +341,9 @@ def test_cancel_booking_updates_status(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            interpreter_name TEXT,
+            interpreter_phone TEXT
         )
         """
     )
@@ -382,7 +389,9 @@ def test_confirmation_post_creates_booking(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            interpreter_name TEXT,
+            interpreter_phone TEXT
         )
         """
     )
@@ -441,6 +450,45 @@ def test_user_login_invalid_credentials_shows_error(client, tmp_path, monkeypatc
     )
     assert response.status_code == 200
     assert "Invalid credentials" in response.get_data(as_text=True)
+
+
+def test_forgot_password_resets_password(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    email = "reset@example.com"
+    old_pwd_hash, old_pwd_salt = functions.hash_password("oldsecret")
+    email_hash, email_salt = functions.hash_email(email)
+    conn.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("Reset", email_hash, email_salt, "000", old_pwd_hash, old_pwd_salt),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post("/forgot_password", data={"email": email})
+    assert response.status_code == 200
+    assert "Om e-postadressen finns registrerad" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute("SELECT password_hash, salt FROM logins").fetchone()
+    conn.close()
+    assert row[0] != old_pwd_hash
+    assert row[1] != old_pwd_salt
 
 
 def test_two_factor_valid_token_authenticates_user(client, tmp_path, monkeypatch):

--- a/website.py
+++ b/website.py
@@ -12,6 +12,7 @@ from itertools import combinations
 import subprocess
 import pyotp
 import urllib.parse
+import secrets
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -36,6 +37,78 @@ app.secret_key = functions.generate_secret_key()
 PASSWORD = os.getenv('password')
 
 
+def ensure_booking_schema(conn):
+    """Ensure new optional columns exist on the bookings table."""
+    try:
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(bookings)")
+        columns = [info[1] for info in cursor.fetchall()]
+        statements = []
+        if 'status' not in columns:
+            statements.append("ALTER TABLE bookings ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+        if 'interpreter_name' not in columns:
+            statements.append("ALTER TABLE bookings ADD COLUMN interpreter_name TEXT")
+        if 'interpreter_phone' not in columns:
+            statements.append("ALTER TABLE bookings ADD COLUMN interpreter_phone TEXT")
+        for statement in statements:
+            cursor.execute(statement)
+        if statements:
+            conn.commit()
+    except sqlite3.OperationalError:
+        # The table might not exist yet (e.g., during first-time setup in tests).
+        pass
+
+
+def send_email_message(recipients, subject, body, bcc=None):
+    """Send an email using SMTP settings if available."""
+    if not recipients or app.config.get('TESTING'):
+        return
+    if isinstance(recipients, str):
+        recipients = [recipients]
+    if bcc and isinstance(bcc, str):
+        bcc = [bcc]
+
+    smtp_username = os.getenv("email")
+    smtp_password = os.getenv('Email_password')
+    smtp_server = os.getenv("smtp_server_address")
+    smtp_port = os.getenv("smtp_port")
+
+    if not all([smtp_username, smtp_password, smtp_server, smtp_port]):
+        return
+
+    msg = MIMEMultipart()
+    msg['From'] = smtp_username
+    msg['To'] = ", ".join(recipients)
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+
+    all_recipients = list(recipients)
+    if bcc:
+        msg['Bcc'] = ", ".join(bcc)
+        all_recipients.extend(bcc)
+
+    try:
+        with smtplib.SMTP(smtp_server, int(smtp_port)) as server:
+            server.starttls()
+            server.login(smtp_username, smtp_password)
+            server.sendmail(smtp_username, all_recipients, msg.as_string())
+    except Exception as exc:
+        print(f"Failed to send email: {exc}")
+
+
+def format_booking_email(name, email, phone, language, time_start, time_end, reference, booking_id):
+    return (
+        f"Boknings-ID: {booking_id}\n"
+        f"Namn: {name}\n"
+        f"E-post: {email}\n"
+        f"Telefon: {phone}\n"
+        f"Språk: {language}\n"
+        f"Starttid: {time_start}\n"
+        f"Sluttid: {time_end}\n"
+        f"Referens: {reference or '-'}"
+    )
+
+
 @app.route('/logout')
 def logout():
     session.pop('authenticated', None)
@@ -49,16 +122,32 @@ def home():
     if session.get('user_id'):
         user_email = session.get('user_email')
         conn = sqlite3.connect('database.db')
+        ensure_booking_schema(conn)
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, language, time_start, time_end, status FROM bookings WHERE email = ?",
+            """
+            SELECT id, language, time_start, time_end, status, interpreter_name, interpreter_phone
+            FROM bookings WHERE email = ? ORDER BY time_start DESC
+            """,
             (user_email,),
         )
-        bookings = cursor.fetchall()
+        rows = cursor.fetchall()
         cursor.execute("SELECT email FROM logins WHERE id = ?", (session['user_id'],))
         row = cursor.fetchone()
         hashed_email = row[0] if row else ''
         conn.close()
+        bookings = [
+            {
+                'id': booking[0],
+                'language': booking[1],
+                'time_start': booking[2],
+                'time_end': booking[3],
+                'status': booking[4] or 'pending',
+                'interpreter_name': booking[5],
+                'interpreter_phone': booking[6],
+            }
+            for booking in rows
+        ]
         message = (
             "Hello,\n\n"
             "Please remove my account from Tolkar.se.\n"
@@ -214,6 +303,7 @@ def get_jobs():
 
     # Connect to the database
     conn = sqlite3.connect('database.db')
+    ensure_booking_schema(conn)
     cursor = conn.cursor()
 
     # Retrieve pending jobs from the database
@@ -237,98 +327,77 @@ def accept_job(job_id):
 
     # Connect to the database
     conn = sqlite3.connect('database.db')
+    ensure_booking_schema(conn)
     cursor = conn.cursor()
 
     # Retrieve job information from the database
     cursor.execute("SELECT name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference FROM bookings WHERE id = ?", (job_id,))
     job_data = cursor.fetchone()
 
+    if not job_data:
+        conn.close()
+        return 'Job not found', 404
+
+    interpreter_name = session.get('tolkar_name')
+    interpreter_phone = session.get('tolkar_phone')
+    interpreter_email = session.get('tolkar_email', '')
+
+    if not interpreter_name or not interpreter_phone:
+        conn.close()
+        return 'Interpreter contact details missing', 400
+
     # Mark the job as accepted instead of deleting
-    cursor.execute("UPDATE bookings SET status='accepted' WHERE id = ?", (job_id,))
+    cursor.execute(
+        "UPDATE bookings SET status='accepted', interpreter_name=?, interpreter_phone=? WHERE id = ?",
+        (interpreter_name, interpreter_phone, job_id),
+    )
     conn.commit()
 
     # Close the database connection
     cursor.close()
     conn.close()
-    def send_tolkar_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-        Kära Herr/Fru,
+    booking_details = format_booking_email(
+        job_data[0],
+        job_data[1],
+        job_data[2],
+        job_data[3],
+        job_data[4],
+        job_data[5],
+        job_data[11],
+        job_id,
+    )
 
-        Här är bekräftelsen för jobb-ID: {job_id}.
+    bcc_address = os.getenv("email")
 
-        Namn: {job_data[0]}
-        E-post: {job_data[1]}
-        Telefonnummer: {job_data[2]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
+    interpreter_subject = f"Bekräftelse – Bokning {job_id}"
+    interpreter_body = (
+        "Kära Herr/Fru,\n\n"
+        "Du har accepterat följande uppdrag:\n\n"
+        f"{booking_details}\n\n"
+        "Kontakta beställaren direkt vid eventuella frågor eller ändringar.\n\n"
+        "Med vänliga hälsningar,\nTolkar-teamet"
+    )
+    send_email_message(interpreter_email, interpreter_subject, interpreter_body, bcc=bcc_address)
 
-        Vänligen granska sökandens kvalifikationer och referenser. Om du behöver ytterligare information eller har några frågor, vänligen kontakta sökanden direkt via det angivna e-postadressen eller telefonnumret.
+    user_subject = f"Din bokning har accepterats – {job_id}"
+    user_body = (
+        "Kära Herr/Fru,\n\n"
+        "Din bokning har accepterats.\n"
+        f"Tolk: {interpreter_name} ({interpreter_phone})\n\n"
+        f"{booking_details}\n\n"
+        "Kontakta tolken minst 24 timmar i förväg vid ändringar eller avbokning.\n\n"
+        "Med vänliga hälsningar,\nTolkar-teamet"
+    )
+    send_email_message(job_data[1], user_subject, user_body, bcc=bcc_address)
 
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
+    accepted_subject = f"Bokning accepterad – {job_id}"
+    accepted_body = (
+        f"{booking_details}\n\n"
+        f"Tolk: {interpreter_name} ({interpreter_phone})\n"
+        f"Tolken e-post: {interpreter_email or '-'}"
+    )
+    send_email_message('accepted@tolkar.se', accepted_subject, accepted_body, bcc=bcc_address)
 
-        Med vänliga hälsningar,
-        Tolkar-teamet"""   
-        # Prepare email message
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the session
-        msg['To'] = session.get('tolkar_email', '')  # Retrieve the email from the session
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain'))
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password') # Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = session.get('tolkar_email', '')  # Retrieve the recipient email from the session
-
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string())
-            
-            
-            
-    def send_user_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-                Kära Herr/Fru,
-
-        Din ansökan för jobb-ID: {job_id} har blivit accepterad.
-        
-        Om du inte har använt vår tjänst, vänligen kontakta oss.
-        Här är din information:   
-        Namn: {job_data[0]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
-        
-        
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
-        
-        
-        Med vänliga hälsningar,
-        Tolkar-teamet"""
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the .env file
-        msg['To'] = job_data[1] # Retrieving the email from the database
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain')) 
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password')# Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = job_data[1] # Retrieve the recipient email from the database
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string()) #Sending the mail
-    send_tolkar_email() # Running the function to send to the translation company
-    send_user_email() # Running the function to send to the user
     return 'Job accepted and email sent'
 
 
@@ -337,14 +406,43 @@ def cancel_booking(booking_id):
     if not session.get('user_id'):
         return redirect(url_for('user_login'))
     conn = sqlite3.connect('database.db')
+    ensure_booking_schema(conn)
     cursor = conn.cursor()
     user_email = session.get('user_email')
+    cursor.execute(
+        """
+        SELECT name, phone, language, time_start, time_end, reference
+        FROM bookings WHERE id=? AND email=? AND status='pending'
+        """,
+        (booking_id, user_email),
+    )
+    booking = cursor.fetchone()
+    if not booking:
+        conn.close()
+        return redirect(url_for('home'))
     cursor.execute(
         "UPDATE bookings SET status='cancelled' WHERE id=? AND email=? AND status='pending'",
         (booking_id, user_email),
     )
     conn.commit()
     conn.close()
+
+    booking_details = format_booking_email(
+        booking[0],
+        user_email,
+        booking[1],
+        booking[2],
+        booking[3],
+        booking[4],
+        booking[5],
+        booking_id,
+    )
+    subject = f"Bokning avbruten – {booking_id}"
+    body = (
+        "Följande bokning har avbrutits av beställaren innan den accepterades:\n\n"
+        f"{booking_details}"
+    )
+    send_email_message('cancelled@tolkar.se', subject, body, bcc=os.getenv('email'))
     return redirect(url_for('home'))
 
 @app.route('/submit', methods=['GET', 'POST'])
@@ -480,8 +578,9 @@ def confirmation():
             phone = session.get('phone')
             conn = sqlite3.connect('database.db')
             cursor = conn.cursor()
+            ensure_booking_schema(conn)
             cursor.execute(
-                "INSERT INTO bookings (name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO bookings (name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference, status, interpreter_name, interpreter_phone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     name,
                     email,
@@ -496,12 +595,39 @@ def confirmation():
                     '',
                     reference,
                     'pending',
+                    None,
+                    None,
                 ),
             )
+            booking_id = cursor.lastrowid
             conn.commit()
 
-            # Close the database connection
+            booking_details = format_booking_email(
+                name,
+                email,
+                phone,
+                language,
+                time_start,
+                time_end,
+                reference,
+                booking_id,
+            )
+
+            order_subject = f"Ny bokning – {booking_id}"
+            order_body = (
+                "En ny bokning har skapats:\n\n"
+                f"{booking_details}"
+            )
+            user_subject = f"Bekräftelse av bokning – {booking_id}"
+            user_body = (
+                "Tack för din bokning! Här kommer en bekräftelse på mottagna uppgifter:\n\n"
+                f"{booking_details}\n\n"
+                "Du får en ny avisering när en tolk har accepterat uppdraget."
+            )
+            bcc_address = os.getenv('email')
             conn.close()
+            send_email_message('order@tolkar.se', order_subject, order_body, bcc=bcc_address)
+            send_email_message(email, user_subject, user_body, bcc=bcc_address)
             time.sleep(1)
             session['submitted'] = False
             if session.get('user_id'):
@@ -511,17 +637,80 @@ def confirmation():
             return "invalid request"
 
 
+@app.route('/forgot_password', methods=['GET', 'POST'])
+def forgot_password():
+    if request.method == 'POST':
+        email = request.form.get('email', '').strip().lower()
+        if not email:
+            return render_template('forgot_password.html', error='Ange e-postadress')
+        conn = sqlite3.connect('database.db')
+        cursor = conn.cursor()
+        try:
+            cursor.execute("SELECT id, email, email_salt FROM logins")
+        except sqlite3.OperationalError:
+            conn.close()
+            message = "Om e-postadressen finns registrerad har ett nytt lösenord skickats."
+            return render_template('forgot_password.html', message=message)
+        user_id = None
+        for user_row in cursor.fetchall():
+            user_id_candidate, email_hash, email_salt = user_row
+            if functions.verify_email(email, email_hash, email_salt):
+                user_id = user_id_candidate
+                break
+        if user_id:
+            new_password = secrets.token_urlsafe(8)
+            pwd_hash, pwd_salt = functions.hash_password(new_password)
+            cursor.execute(
+                "UPDATE logins SET password_hash = ?, salt = ? WHERE id = ?",
+                (pwd_hash, pwd_salt, user_id),
+            )
+            conn.commit()
+            conn.close()
+            subject = "Återställning av lösenord"
+            body = (
+                "Hej,\n\n"
+                "Ditt lösenord har återställts. Använd det temporära lösenordet nedan för att logga in och byt det därefter:\n\n"
+                f"{new_password}\n\n"
+                "Med vänliga hälsningar,\nTolkar-teamet"
+            )
+            send_email_message(email, subject, body, bcc=os.getenv('email'))
+        else:
+            conn.close()
+        message = "Om e-postadressen finns registrerad har ett nytt lösenord skickats."
+        return render_template('forgot_password.html', message=message)
+    return render_template('forgot_password.html')
+
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
+        email = request.form.get('email', '').strip()
         password = request.form['password']
+        interpreter_name = request.form.get('name', '').strip()
+        interpreter_phone = request.form.get('phone', '').strip()
+        if not interpreter_name or not interpreter_phone:
+            return render_template(
+                'login.html',
+                error='Name and phone number are required',
+                email=email,
+                name=interpreter_name,
+                phone=interpreter_phone,
+            )
         if password == PASSWORD:
-            # Store the email in the session
-            session['tolkar_email'] = request.form['email']
+            # Store interpreter contact details in the session
+            session['tolkar_email'] = email
+            session['tolkar_name'] = interpreter_name
+            session['tolkar_phone'] = interpreter_phone
             session['authenticated'] = True
             return redirect(url_for('get_jobs'))
         else:
-            return render_template('login.html', error='Invalid password')
+            return render_template(
+                'login.html',
+                error='Invalid password',
+                email=email,
+                name=interpreter_name,
+                phone=interpreter_phone,
+            )
     return render_template('login.html')
 
 @app.errorhandler(404)
@@ -556,11 +745,7 @@ if __name__ == '__main__':
                     reference TEXT,
                     status TEXT NOT NULL DEFAULT "pending")''')
 
-    # Ensure the status column exists for older databases
-    cursor.execute("PRAGMA table_info(bookings)")
-    columns = [info[1] for info in cursor.fetchall()]
-    if 'status' not in columns:
-        cursor.execute("ALTER TABLE bookings ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+    ensure_booking_schema(conn)
 
     # Create the 'logins' table if it doesn't exist
     cursor.execute('''CREATE TABLE IF NOT EXISTS logins


### PR DESCRIPTION
## Summary
- add a refresh control and richer status details on the customer bookings dashboard
- send notification emails for new, accepted, and cancelled bookings while storing interpreter contact info
- implement a forgot-password flow, require interpreter contact details at login, and extend automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c878be3758832d91212940eebc7d52