### PR TITLE
Implement booking notifications and password reset functionality

### DIFF
--- a/static/style/auth.css
+++ b/static/style/auth.css
@@ -38,6 +38,21 @@ button:hover {
     color: red;
 }
 
+.form-hint {
+    font-size: 0.9em;
+    color: #555;
+    margin-bottom: 10px;
+}
+
+.form-hint a {
+    color: #3498db;
+    text-decoration: none;
+}
+
+.form-hint a:hover {
+    text-decoration: underline;
+}
+
 /* Mobile-specific styles */
 @media (max-width: 768px) {
     input[type="text"],

--- a/static/style/dashboard.css
+++ b/static/style/dashboard.css
@@ -95,6 +95,10 @@
     font-weight: bold;
 }
 
+.status {
+    font-weight: bold;
+}
+
 @media (max-width: 600px) {
     .dashboard-container {
         padding: 15px;

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Glömt lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Glömt lösenord</h1>
+{% if message %}
+<p class="form-hint">{{ message }}</p>
+{% endif %}
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
+<form method="post">
+  <label for="email">E-post:</label>
+  <input type="email" id="email" name="email" required>
+  <input type="submit" value="Skicka återställningslänk">
+</form>
+<p class="form-hint"><a href="{{ url_for('user_login') }}">Tillbaka till inloggning</a></p>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -24,13 +24,21 @@
         </tr>
         {% for b in bookings %}
         <tr>
-          <td>{{ b[1] }}</td>
-          <td>{{ b[2] }}</td>
-          <td>{{ b[3] }}</td>
-          <td class="status status-{{ b[4] }}">{{ b[4] }}</td>
+          <td>{{ b.language }}</td>
+          <td>{{ b.time_start }}</td>
+          <td>{{ b.time_end }}</td>
+          <td class="status status-{{ b.status }}">
+            {% if b.status == 'accepted' and (b.interpreter_name or b.interpreter_phone) %}
+            Accepted by {{ b.interpreter_name or 'tolken' }} – {{ b.interpreter_phone or 'saknas' }}
+            {% elif b.status == 'cancelled' %}
+            Cancelled
+            {% else %}
+            {{ b.status }}
+            {% endif %}
+          </td>
           <td>
-            {% if b[4] == 'pending' %}
-            <form method="post" action="{{ url_for('cancel_booking', booking_id=b[0]) }}">
+            {% if b.status == 'pending' %}
+            <form method="post" action="{{ url_for('cancel_booking', booking_id=b.id) }}">
               <button type="submit" class="cancel-button">Avbryt</button>
             </form>
             {% endif %}
@@ -43,6 +51,7 @@
     <p>Du har inga bokningar.</p>
     {% endif %}
     <div class="dashboard-actions">
+      <a href="{{ url_for('home') }}" class="dashboard-button">Uppdatera</a>
       <a href="{{ url_for('index') }}" class="dashboard-button">Gör ny bokning</a>
       <a href="{{ url_for('logout') }}" class="dashboard-button">Logga ut</a>
       <a href="{{ removal_link }}" class="dashboard-button">Ta bort konto</a>

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,10 +12,15 @@
     {% if error %}
         <p class="error">{{ error }}</p>
     {% endif %}
+    <label for="name">Fullständigt namn:</label>
+    <input type="text" id="name" name="name" required>
+    <label for="phone">Telefonnummer:</label>
+    <input type="tel" id="phone" name="phone" required>
     <label for="email">Email:</label>
     <input type="email" id="email" name="email" required>
     <label for="password">Password:</label>
     <input type="password" id="password" name="password" required>
+    <p class="form-hint">Namnet och telefonnumret visas för beställaren när du accepterar ett uppdrag.</p>
     <input type="submit" value="Login">
 </form>
 

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Återställ lösenord{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Återställ lösenord</h1>
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
+{% if token %}
+<form method="post">
+  <input type="hidden" name="token" value="{{ token }}">
+  <label for="password">Nytt lösenord:</label>
+  <input type="password" id="password" name="password" required>
+  <label for="confirm_password">Bekräfta lösenord:</label>
+  <input type="password" id="confirm_password" name="confirm_password" required>
+  <input type="submit" value="Uppdatera lösenord">
+</form>
+{% endif %}
+<p class="form-hint"><a href="{{ url_for('user_login') }}">Tillbaka till inloggning</a></p>
+{% endblock %}

--- a/templates/reset_password_success.html
+++ b/templates/reset_password_success.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Lösenord uppdaterat{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style/auth.css') }}">
+{% endblock %}
+{% block content %}
+<h1>Lösenordet är uppdaterat</h1>
+<p>Ditt lösenord har uppdaterats. Du kan nu logga in med ditt nya lösenord.</p>
+<p class="form-hint"><a href="{{ url_for('user_login') }}">Tillbaka till inloggning</a></p>
+{% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -13,4 +13,5 @@
   <input type="password" id="password" name="password" required><br><br>
   <input type="submit" value="Logga in">
 </form>
+<p class="form-hint"><a href="{{ url_for('forgot_password') }}">Glömt lösenord?</a></p>
 {% endblock %}

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -16,7 +16,10 @@ def setup_db(tmp_path):
             phone TEXT NOT NULL,
             language TEXT NOT NULL,
             time_start TEXT NOT NULL,
-            time_end TEXT NOT NULL
+            time_end TEXT NOT NULL,
+            status TEXT,
+            interpreter_name TEXT,
+            interpreter_phone TEXT
         )
         """
     )

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -336,7 +336,9 @@ def test_cancel_booking_updates_status(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            interpreter_name TEXT,
+            interpreter_phone TEXT
         )
         """
     )
@@ -382,7 +384,9 @@ def test_confirmation_post_creates_booking(client, tmp_path, monkeypatch):
             marking TEXT,
             avtalskund_marking TEXT,
             reference TEXT,
-            status TEXT NOT NULL DEFAULT 'pending'
+            status TEXT NOT NULL DEFAULT 'pending',
+            interpreter_name TEXT,
+            interpreter_phone TEXT
         )
         """
     )
@@ -534,3 +538,113 @@ def test_two_factor_invalid_token_shows_error(client, tmp_path, monkeypatch):
     with client.session_transaction() as sess:
         assert "user_id" not in sess
         assert sess.get("pending_user_id") == user_id
+
+
+def test_forgot_password_creates_reset_entry(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE password_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+        )"""
+    )
+    email = "reset@example.com"
+    pwd_hash, pwd_salt = functions.hash_password("secret")
+    email_hash, email_salt = functions.hash_email(email)
+    conn.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("Test", email_hash, email_salt, "000", pwd_hash, pwd_salt),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post("/forgot_password", data={"email": email})
+    assert response.status_code == 200
+    assert "återställningslänk" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute("SELECT token FROM password_resets").fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0]
+
+
+def test_reset_password_updates_user_credentials(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = sqlite3.connect("database.db")
+    conn.execute(
+        """CREATE TABLE logins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            email_salt TEXT NOT NULL,
+            phone TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            salt TEXT NOT NULL,
+            organization_number TEXT,
+            billing_address TEXT,
+            email_billing_address TEXT,
+            totp_secret TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE password_resets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+        )"""
+    )
+    email = "user@example.com"
+    old_pwd_hash, old_pwd_salt = functions.hash_password("oldpass")
+    email_hash, email_salt = functions.hash_email(email)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO logins (name, email, email_salt, phone, password_hash, salt, organization_number, billing_address, email_billing_address, totp_secret) VALUES (?, ?, ?, ?, ?, ?, '', '', '', '')",
+        ("Test", email_hash, email_salt, "000", old_pwd_hash, old_pwd_salt),
+    )
+    user_id = cursor.lastrowid
+    token = "test-token"
+    cursor.execute(
+        "INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)",
+        (user_id, token, "2999-01-01T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    new_password = "newpass123"
+    response = client.post(
+        "/reset_password",
+        data={
+            "token": token,
+            "password": new_password,
+            "confirm_password": new_password,
+        },
+    )
+    assert response.status_code == 200
+    assert "Lösenordet är uppdaterat" in response.get_data(as_text=True)
+
+    conn = sqlite3.connect("database.db")
+    row = conn.execute("SELECT password_hash, salt FROM logins WHERE id = ?", (user_id,)).fetchone()
+    assert functions.verify_password(new_password, row[0], row[1])
+    remaining = conn.execute("SELECT token FROM password_resets WHERE user_id = ?", (user_id,)).fetchone()
+    conn.close()
+    assert remaining is None

--- a/website.py
+++ b/website.py
@@ -12,6 +12,7 @@ from itertools import combinations
 import subprocess
 import pyotp
 import urllib.parse
+import secrets
 
 languages = [
     "Franska", "Engelska", "Tyska", "Spanska",
@@ -36,11 +37,80 @@ app.secret_key = functions.generate_secret_key()
 PASSWORD = os.getenv('password')
 
 
+def send_email(to_addresses, subject, body, bcc=None):
+    """Send an email if SMTP settings are configured."""
+
+    smtp_username = os.getenv("email")
+    smtp_password = os.getenv("Email_password")
+    smtp_server = os.getenv("smtp_server_address")
+    smtp_port = os.getenv("smtp_port")
+
+    if not all([smtp_username, smtp_password, smtp_server, smtp_port]):
+        print("Email configuration missing; skipping email send.")
+        return False
+
+    if isinstance(to_addresses, str):
+        to_addresses = [to_addresses]
+    to_addresses = [addr for addr in to_addresses if addr]
+    if not to_addresses:
+        return False
+
+    msg = MIMEMultipart()
+    msg['From'] = smtp_username
+    msg['To'] = ", ".join(to_addresses)
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+
+    bcc_list = []
+    if bcc:
+        if isinstance(bcc, str):
+            bcc_list = [bcc]
+        else:
+            bcc_list = [addr for addr in bcc if addr]
+    if smtp_username not in to_addresses and smtp_username not in bcc_list:
+        bcc_list.append(smtp_username)
+    if bcc_list:
+        msg['Bcc'] = ", ".join(bcc_list)
+
+    try:
+        with smtplib.SMTP(smtp_server, int(smtp_port)) as server:
+            server.starttls()
+            server.login(smtp_username, smtp_password)
+            recipients = list(dict.fromkeys(to_addresses + bcc_list))
+            server.sendmail(smtp_username, recipients, msg.as_string())
+        return True
+    except Exception as exc:
+        print(f"Failed to send email: {exc}")
+        return False
+
+
+def format_booking_summary(booking):
+    """Return a multiline summary string for a booking."""
+
+    lines = [
+        f"Boknings-ID: {booking.get('id', '')}",
+        f"Namn: {booking['name']}",
+        f"E-post: {booking['email']}",
+        f"Telefon: {booking['phone']}",
+        f"Språk: {booking['language']}",
+        f"Starttid: {booking['time_start']}",
+        f"Sluttid: {booking['time_end']}",
+        f"Organisationsnummer: {booking.get('organization_number', '')}",
+        f"Fakturaadress: {booking.get('billing_address', '')}",
+        f"Faktura e-post: {booking.get('email_billing_address', '')}",
+        f"Referens: {booking.get('reference', '')}",
+    ]
+    return "\n".join(lines)
+
+
 @app.route('/logout')
 def logout():
     session.pop('authenticated', None)
     session.pop('user_id', None)
     session.pop('user_email', None)
+    session.pop('tolkar_email', None)
+    session.pop('interpreter_name', None)
+    session.pop('interpreter_phone', None)
     return redirect(url_for('home'))
 
 
@@ -49,12 +119,28 @@ def home():
     if session.get('user_id'):
         user_email = session.get('user_email')
         conn = sqlite3.connect('database.db')
+        conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, language, time_start, time_end, status FROM bookings WHERE email = ?",
+            """
+            SELECT id, language, time_start, time_end, status, interpreter_name, interpreter_phone
+            FROM bookings WHERE email = ? ORDER BY time_start DESC
+            """,
             (user_email,),
         )
-        bookings = cursor.fetchall()
+        rows = cursor.fetchall()
+        bookings = [
+            {
+                'id': row['id'],
+                'language': row['language'],
+                'time_start': row['time_start'],
+                'time_end': row['time_end'],
+                'status': row['status'],
+                'interpreter_name': row['interpreter_name'] or '',
+                'interpreter_phone': row['interpreter_phone'] or '',
+            }
+            for row in rows
+        ]
         cursor.execute("SELECT email FROM logins WHERE id = ?", (session['user_id'],))
         row = cursor.fetchone()
         hashed_email = row[0] if row else ''
@@ -203,6 +289,97 @@ def two_factor():
         return render_template('verify_2fa.html', error='Invalid code', secret=display_secret)
     return render_template('verify_2fa.html', secret=display_secret)
 
+
+@app.route('/forgot_password', methods=['GET', 'POST'])
+def forgot_password():
+    if request.method == 'POST':
+        email = request.form.get('email', '').strip().lower()
+        if not email:
+            return render_template('forgot_password.html', error='Ange en e-postadress.')
+
+        conn = sqlite3.connect('database.db')
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute('SELECT id, email, email_salt FROM logins')
+        user_row = None
+        for row in cursor.fetchall():
+            if functions.verify_email(email, row['email'], row['email_salt']):
+                user_row = row
+                break
+
+        if user_row:
+            token = secrets.token_urlsafe(32)
+            expires_at = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+            cursor.execute('DELETE FROM password_resets WHERE user_id = ?', (user_row['id'],))
+            cursor.execute(
+                'INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)',
+                (user_row['id'], token, expires_at),
+            )
+            conn.commit()
+            reset_link = url_for('reset_password', token=token, _external=True)
+            body = (
+                "Hej!\n\n"
+                "Vi har fått en begäran om att återställa ditt lösenord på Tolkar.se.\n"
+                "Använd länken nedan för att välja ett nytt lösenord. Länken är giltig i 1 timme.\n\n"
+                f"{reset_link}\n\n"
+                "Om du inte har begärt återställningen kan du ignorera detta mejl.\n\n"
+                "Hälsningar,\nTolkar.se"
+            )
+            send_email([email], 'Återställ ditt lösenord', body)
+        else:
+            conn.commit()
+        conn.close()
+        message = 'Om adressen finns registrerad har ett mejl med återställningslänk skickats.'
+        return render_template('forgot_password.html', message=message)
+    return render_template('forgot_password.html')
+
+
+@app.route('/reset_password', methods=['GET', 'POST'])
+def reset_password():
+    token = request.values.get('token', '').strip()
+    if not token:
+        return render_template('reset_password.html', error='Ogiltig eller förfallen länk.')
+
+    conn = sqlite3.connect('database.db')
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    cursor.execute('SELECT user_id, expires_at FROM password_resets WHERE token = ?', (token,))
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return render_template('reset_password.html', error='Ogiltig eller förfallen länk.')
+
+    expires_at = None
+    if row['expires_at']:
+        try:
+            expires_at = datetime.fromisoformat(row['expires_at'])
+        except ValueError:
+            expires_at = None
+    if expires_at and expires_at < datetime.utcnow():
+        cursor.execute('DELETE FROM password_resets WHERE token = ?', (token,))
+        conn.commit()
+        conn.close()
+        return render_template('reset_password.html', error='Ogiltig eller förfallen länk.')
+
+    if request.method == 'POST':
+        password = request.form.get('password', '')
+        confirm_password = request.form.get('confirm_password', '')
+        if not password:
+            conn.close()
+            return render_template('reset_password.html', token=token, error='Lösenordet får inte vara tomt.')
+        if password != confirm_password:
+            conn.close()
+            return render_template('reset_password.html', token=token, error='Lösenorden matchar inte.')
+        pwd_hash, salt = functions.hash_password(password)
+        cursor.execute('UPDATE logins SET password_hash = ?, salt = ? WHERE id = ?', (pwd_hash, salt, row['user_id']))
+        cursor.execute('DELETE FROM password_resets WHERE token = ?', (token,))
+        conn.commit()
+        conn.close()
+        return render_template('reset_password_success.html')
+
+    conn.close()
+    return render_template('reset_password.html', token=token)
+
 @app.route('/health')
 def health():
     """Health check endpoint used by deployment platforms."""
@@ -230,106 +407,82 @@ def get_jobs():
 
 @app.route('/jobs/<int:job_id>', methods=['POST']) # The action to accept the job
 def accept_job(job_id):
-    print(job_id)
     # Check if the user is authenticated
-    if 'authenticated' not in session:
+    if not session.get('authenticated'):
         return render_template('login.html')
+
+    interpreter_email = session.get('tolkar_email', '')
+    interpreter_name = (session.get('interpreter_name') or '').strip()
+    interpreter_phone = (session.get('interpreter_phone') or '').strip()
+    if not interpreter_name or not interpreter_phone:
+        return 'Tolkuppgifter saknas.', 400
 
     # Connect to the database
     conn = sqlite3.connect('database.db')
+    conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
 
     # Retrieve job information from the database
-    cursor.execute("SELECT name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference FROM bookings WHERE id = ?", (job_id,))
-    job_data = cursor.fetchone()
+    cursor.execute("SELECT * FROM bookings WHERE id = ?", (job_id,))
+    booking_row = cursor.fetchone()
+    if booking_row is None:
+        conn.close()
+        return 'Bokningen kunde inte hittas.', 404
+    if booking_row['status'] == 'accepted':
+        conn.close()
+        return 'Bokningen är redan accepterad.', 400
 
-    # Mark the job as accepted instead of deleting
-    cursor.execute("UPDATE bookings SET status='accepted' WHERE id = ?", (job_id,))
+    cursor.execute(
+        "UPDATE bookings SET status='accepted', interpreter_name=?, interpreter_phone=? WHERE id = ?",
+        (interpreter_name, interpreter_phone, job_id),
+    )
     conn.commit()
-
-    # Close the database connection
-    cursor.close()
     conn.close()
-    def send_tolkar_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-        Kära Herr/Fru,
 
-        Här är bekräftelsen för jobb-ID: {job_id}.
+    booking = {
+        'id': booking_row['id'],
+        'name': booking_row['name'],
+        'email': booking_row['email'],
+        'phone': booking_row['phone'],
+        'language': booking_row['language'],
+        'time_start': booking_row['time_start'],
+        'time_end': booking_row['time_end'],
+        'organization_number': booking_row['organization_number'] or '',
+        'billing_address': booking_row['billing_address'] or '',
+        'email_billing_address': booking_row['email_billing_address'] or '',
+        'reference': booking_row['reference'] or '',
+    }
+    summary = format_booking_summary(booking)
 
-        Namn: {job_data[0]}
-        E-post: {job_data[1]}
-        Telefonnummer: {job_data[2]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
+    interpreter_subject = f"Bekräftelse på accepterat uppdrag #{job_id}"
+    interpreter_body = (
+        f"Hej {interpreter_name},\n\n"
+        "Du har accepterat följande uppdrag:\n\n"
+        f"{summary}\n\n"
+        "Kontakta beställaren vid frågor eller ändringar.\n\n"
+        "Hälsningar,\nTolkar.se"
+    )
+    send_email([interpreter_email], interpreter_subject, interpreter_body)
 
-        Vänligen granska sökandens kvalifikationer och referenser. Om du behöver ytterligare information eller har några frågor, vänligen kontakta sökanden direkt via det angivna e-postadressen eller telefonnumret.
+    user_subject = f"Din bokning har accepterats – ärende #{job_id}"
+    user_body = (
+        f"Hej {booking['name']},\n\n"
+        f"Din bokning har accepterats av {interpreter_name} – {interpreter_phone}.\n"
+        "Kontakta tolken direkt vid mindre ändringar eller avbokning (minst 24 timmar i förväg).\n\n"
+        f"{summary}\n\n"
+        "Tack för att du använder Tolkar.se!"
+    )
+    send_email([booking['email']], user_subject, user_body)
 
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
+    accepted_subject = f"Bokning #{job_id} accepterad"
+    accepted_body = (
+        "Följande uppdrag har accepterats:\n\n"
+        f"{summary}\n\n"
+        f"Tolken: {interpreter_name} – {interpreter_phone} ({interpreter_email})"
+    )
+    send_email(['accepted@tolkar.se'], accepted_subject, accepted_body)
 
-        Med vänliga hälsningar,
-        Tolkar-teamet"""   
-        # Prepare email message
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the session
-        msg['To'] = session.get('tolkar_email', '')  # Retrieve the email from the session
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain'))
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password') # Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = session.get('tolkar_email', '')  # Retrieve the recipient email from the session
-
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string())
-            
-            
-            
-    def send_user_email():
-        # Making the email body and subject
-        email_subject = f"Translation Application - Job ID: {job_id}"
-        email_body = f"""
-                Kära Herr/Fru,
-
-        Din ansökan för jobb-ID: {job_id} har blivit accepterad.
-        
-        Om du inte har använt vår tjänst, vänligen kontakta oss.
-        Här är din information:   
-        Namn: {job_data[0]}
-        Önskat språk: {job_data[3]}
-        Starttid: {job_data[4]}
-        Sluttid: {job_data[5]}
-        
-        
-        Tack för att du valde vår tjänst. Vi uppskattar ditt stöd.
-        
-        
-        Med vänliga hälsningar,
-        Tolkar-teamet"""
-        msg = MIMEMultipart()
-        msg['From'] = os.getenv("email") # Retrieving the email from the .env file
-        msg['To'] = job_data[1] # Retrieving the email from the database
-        msg['Subject'] = email_subject # Getting the subject
-        msg.attach(MIMEText(email_body, 'plain')) 
-        smtp_username = os.getenv("email")# Getting the email for the sender
-        smtp_password = os.getenv('Email_password')# Getting the password for the sender
-        msg['Bcc'] = smtp_username # Adding the secret email to send to self.
-        smtp_server = os.getenv("smtp_server_address")  # Connect to the SMTP server
-        smtp_port = os.getenv("smtp_port")# Connect to the SMTP server
-        recipient_email = job_data[1] # Retrieve the recipient email from the database
-        with smtplib.SMTP(smtp_server, smtp_port) as server: # Sending the email
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.sendmail(smtp_username, [recipient_email, msg['Bcc']], msg.as_string()) #Sending the mail
-    send_tolkar_email() # Running the function to send to the translation company
-    send_user_email() # Running the function to send to the user
-    return 'Job accepted and email sent'
+    return 'Job accepted and notifications sent'
 
 
 @app.route('/cancel_booking/<int:booking_id>', methods=['POST'])
@@ -337,14 +490,41 @@ def cancel_booking(booking_id):
     if not session.get('user_id'):
         return redirect(url_for('user_login'))
     conn = sqlite3.connect('database.db')
+    conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
     user_email = session.get('user_email')
+    cursor.execute(
+        "SELECT * FROM bookings WHERE id=? AND email=? AND status='pending'",
+        (booking_id, user_email),
+    )
+    booking_row = cursor.fetchone()
+    if not booking_row:
+        conn.close()
+        return redirect(url_for('home'))
     cursor.execute(
         "UPDATE bookings SET status='cancelled' WHERE id=? AND email=? AND status='pending'",
         (booking_id, user_email),
     )
     conn.commit()
     conn.close()
+
+    booking = {
+        'id': booking_row['id'],
+        'name': booking_row['name'],
+        'email': booking_row['email'],
+        'phone': booking_row['phone'],
+        'language': booking_row['language'],
+        'time_start': booking_row['time_start'],
+        'time_end': booking_row['time_end'],
+        'organization_number': booking_row['organization_number'] or '',
+        'billing_address': booking_row['billing_address'] or '',
+        'email_billing_address': booking_row['email_billing_address'] or '',
+        'reference': booking_row['reference'] or '',
+    }
+    summary = format_booking_summary(booking)
+    cancel_subject = f"Bokning #{booking_id} avbruten"
+    cancel_body = "Beställaren har avbrutit följande bokning:\n\n" + summary
+    send_email(['cancelled@tolkar.se'], cancel_subject, cancel_body)
     return redirect(url_for('home'))
 
 @app.route('/submit', methods=['GET', 'POST'])
@@ -481,7 +661,13 @@ def confirmation():
             conn = sqlite3.connect('database.db')
             cursor = conn.cursor()
             cursor.execute(
-                "INSERT INTO bookings (name, email, phone, language, time_start, time_end, organization_number, billing_address, email_billing_address, marking, avtalskund_marking, reference, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                """
+                INSERT INTO bookings (
+                    name, email, phone, language, time_start, time_end,
+                    organization_number, billing_address, email_billing_address,
+                    marking, avtalskund_marking, reference, status, interpreter_name, interpreter_phone
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
                 (
                     name,
                     email,
@@ -496,9 +682,41 @@ def confirmation():
                     '',
                     reference,
                     'pending',
+                    '',
+                    '',
                 ),
             )
+            booking_id = cursor.lastrowid
             conn.commit()
+
+            booking = {
+                'id': booking_id,
+                'name': name,
+                'email': email,
+                'phone': phone,
+                'language': language,
+                'time_start': time_start,
+                'time_end': time_end,
+                'organization_number': organization_number or '',
+                'billing_address': billing_address or '',
+                'email_billing_address': email_billing_address or '',
+                'reference': reference or '',
+            }
+            summary = format_booking_summary(booking)
+
+            order_subject = f"Ny bokning #{booking_id}"
+            order_body = "En ny bokning har skapats:\n\n" + summary
+            send_email(['order@tolkar.se'], order_subject, order_body)
+
+            user_subject = f"Tack för din bokning – ärende #{booking_id}"
+            user_body = (
+                f"Hej {name},\n\n"
+                "Här är en kopia av din beställning på Tolkar.se.\n\n"
+                f"{summary}\n\n"
+                "Vi återkommer när en tolk har accepterat uppdraget.\n\n"
+                "Hälsningar,\nTolkar.se"
+            )
+            send_email([email], user_subject, user_body)
 
             # Close the database connection
             conn.close()
@@ -516,8 +734,16 @@ def login():
     if request.method == 'POST':
         password = request.form['password']
         if password == PASSWORD:
+            interpreter_name = request.form.get('name', '').strip()
+            interpreter_phone = request.form.get('phone', '').strip()
             # Store the email in the session
             session['tolkar_email'] = request.form['email']
+            if interpreter_name:
+                session['interpreter_name'] = interpreter_name
+            if interpreter_phone:
+                session['interpreter_phone'] = interpreter_phone
+            session.setdefault('interpreter_name', interpreter_name)
+            session.setdefault('interpreter_phone', interpreter_phone)
             session['authenticated'] = True
             return redirect(url_for('get_jobs'))
         else:
@@ -554,13 +780,19 @@ if __name__ == '__main__':
                     marking TEXT,
                     avtalskund_marking TEXT,
                     reference TEXT,
-                    status TEXT NOT NULL DEFAULT "pending")''')
+                    status TEXT NOT NULL DEFAULT "pending",
+                    interpreter_name TEXT,
+                    interpreter_phone TEXT)''')
 
     # Ensure the status column exists for older databases
     cursor.execute("PRAGMA table_info(bookings)")
     columns = [info[1] for info in cursor.fetchall()]
     if 'status' not in columns:
         cursor.execute("ALTER TABLE bookings ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+    if 'interpreter_name' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN interpreter_name TEXT")
+    if 'interpreter_phone' not in columns:
+        cursor.execute("ALTER TABLE bookings ADD COLUMN interpreter_phone TEXT")
 
     # Create the 'logins' table if it doesn't exist
     cursor.execute('''CREATE TABLE IF NOT EXISTS logins
@@ -588,6 +820,13 @@ if __name__ == '__main__':
     for col in extra_cols:
         if col not in login_columns:
             cursor.execute(f"ALTER TABLE logins ADD COLUMN {col} TEXT")
+
+    cursor.execute('''CREATE TABLE IF NOT EXISTS password_resets
+                    (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    token TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    FOREIGN KEY(user_id) REFERENCES logins(id) ON DELETE CASCADE)''')
 
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- send structured notification emails for new, accepted and cancelled bookings while storing interpreter contact details
- surface interpreter contact information in the customer dashboard with a manual refresh control
- add a complete forgot/reset password workflow and supporting tests plus UI hints for translators and customers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c878be3758832d91212940eebc7d52